### PR TITLE
Add chunked download method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@
 *.o
 *.a
 mkmf.log
+.ruby-version

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ SwiftClient offers the following requests:
 * put_object(object_name, data_or_io, container_name, headers = {}) -> HTTParty::Response
 * post_object(object_name, container_name, headers = {}) -> HTTParty::Response
 * get_object(object_name, container_name) -> HTTParty::Response
-* get_object_chunked(object_name, container_name){|chunk| save chunk } -> Nil
+* get_object(object_name, container_name){|chunk| save chunk } -> HTTParty::Response
 * head_object(object_name, container_name) -> HTTParty::Response
 * delete_object(object_name, container_name) -> HTTParty::Response
 * get_objects(container_name, query = {}) -> HTTParty::Response
@@ -150,11 +150,11 @@ SwiftClient offers the following requests:
 * bulk_delete(entries) -> entries
 
 ### Getting large objects
-The `get_object` method is suitable for small objects that easily fit in memory. For larger objects, the `get_object_chunked` method should be used to prevent memory exhaustion.
+The `get_object` method with out a block is suitable for small objects that easily fit in memory. For larger objects, specify a block to process chunked data as it comes in.
 
 ```ruby
 File.open("/tmp/output", "wb") do |file_io|
-  swift_client.get_object_chunked("/large/object", "container") do |chunk|
+  swift_client.get_object("/large/object", "container") do |chunk|
     file_io.write(chunk)
   end
 end

--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ SwiftClient offers the following requests:
 * put_object(object_name, data_or_io, container_name, headers = {}) -> HTTParty::Response
 * post_object(object_name, container_name, headers = {}) -> HTTParty::Response
 * get_object(object_name, container_name) -> HTTParty::Response
+* get_object_chunked(object_name, container_name){|chunk| save chunk } -> Nil
 * head_object(object_name, container_name) -> HTTParty::Response
 * delete_object(object_name, container_name) -> HTTParty::Response
 * get_objects(container_name, query = {}) -> HTTParty::Response
@@ -147,6 +148,17 @@ SwiftClient offers the following requests:
 * public_url(object_name, container_name) -> HTTParty::Response
 * temp_url(object_name, container_name, options = {}) -> HTTParty::Response
 * bulk_delete(entries) -> entries
+
+### Getting large objects
+The `get_object` method is suitable for small objects that easily fit in memory. For larger objects, the `get_object_chunked` method should be used to prevent memory exhaustion.
+
+```ruby
+File.open("/tmp/output", "wb") do |file_io|
+  swift_client.get_object_chunked("/large/object", "container") do |chunk|
+    file_io.write(chunk)
+  end
+end
+```
 
 ## Re-Using/Sharing/Caching Auth Tokens
 

--- a/lib/swift_client.rb
+++ b/lib/swift_client.rb
@@ -117,7 +117,7 @@ class SwiftClient
   def get_object(object_name, container_name, &block)
     raise(EmptyNameError) if object_name.empty? || container_name.empty?
 
-    request :get, "/#{container_name}/#{object_name}", &block
+    request(:get, "/#{container_name}/#{object_name}", block ? { :stream_body => true } : {}, &block)
   end
 
   def head_object(object_name, container_name)
@@ -190,7 +190,7 @@ class SwiftClient
 
     stream_pos = opts[:body_stream].pos if opts[:body_stream]
 
-    response = HTTParty.send(method, "#{storage_url}#{path}", opts.merge(:headers => headers).merge(block ? {:stream_body => true} : {}), &block)
+    response = HTTParty.send(method, "#{storage_url}#{path}", opts.merge(:headers => headers), &block)
 
     if response.code == 401
       authenticate

--- a/lib/swift_client.rb
+++ b/lib/swift_client.rb
@@ -218,7 +218,7 @@ class SwiftClient
     headers["Accept"] = "application/json"
     uri = URI("#{storage_url}#{path}")
     Net::HTTP.start(uri.host, uri.port, :use_ssl => uri.scheme == "https") do |http|
-      req = Net::HTTP::Get.new uri
+      req = Net::HTTP::Get.new uri.to_s
       headers.each{|h,v| req[h] = v if v}
       http.request req do |response|
         response.read_body(&block)

--- a/lib/swift_client/version.rb
+++ b/lib/swift_client/version.rb
@@ -1,5 +1,4 @@
 
 class SwiftClient
-  VERSION = "0.1.4"
+  VERSION = "0.2.0"
 end
-

--- a/test/swift_client_test.rb
+++ b/test/swift_client_test.rb
@@ -277,17 +277,14 @@ class SwiftClientTest < MiniTest::Test
 
   def test_get_object
     stub_request(:get, "https://example.com/v1/AUTH_account/container/object").with(:headers => { "Accept" => "application/json", "X-Auth-Token" => "Token" }).to_return(:status => 200, :body => "Body", :headers => {})
-
-    assert_equal "Body", @swift_client.get_object("object", "container").body
-  end
-
-  def test_get_object_chunked
     block_res = 0
 
     large_body = "Body" * 16384
     stub_request(:get, "https://example.com/v1/AUTH_account/container/large_object").with(:headers => { "Accept" => "application/json", "X-Auth-Token" => "Token" }).to_return(:status => 200, :body => large_body, :headers => {})
 
-    @swift_client.get_object_chunked("large_object", "container") do |chunk|
+    assert_equal "Body", @swift_client.get_object("object", "container").body
+
+    @swift_client.get_object("large_object", "container") do |chunk|
       block_res += chunk.length
     end
 

--- a/test/swift_client_test.rb
+++ b/test/swift_client_test.rb
@@ -281,6 +281,19 @@ class SwiftClientTest < MiniTest::Test
     assert_equal "Body", @swift_client.get_object("object", "container").body
   end
 
+  def test_get_object_chunked
+    block_res = 0
+
+    large_body = "Body" * 16384
+    stub_request(:get, "https://example.com/v1/AUTH_account/container/large_object").with(:headers => { "Accept" => "application/json", "X-Auth-Token" => "Token" }).to_return(:status => 200, :body => large_body, :headers => {})
+
+    @swift_client.get_object_chunked("large_object", "container") do |chunk|
+      block_res += chunk.length
+    end
+
+    assert_equal block_res, large_body.length
+  end
+
   def test_head_object
     stub_request(:head, "https://example.com/v1/AUTH_account/container/object").with(:headers => { "Accept" => "application/json", "X-Auth-Token" => "Token" }).to_return(:status => 200, :body => "", :headers => {})
 
@@ -340,4 +353,3 @@ class SwiftClientTest < MiniTest::Test
     assert @swift_client.temp_url("object", "container", :expires_in => 86400) =~ %r{https://example.com/v1/AUTH_account/container/object\?temp_url_sig=[a-f0-9]{40}&temp_url_expires=1086400}
   end
 end
-


### PR DESCRIPTION
Noticed that download large objects would store the entirety of their content in memory and would exhaust memory on small systems. Added a `get_object_chunked` that uses raw `Net:HTTP` and `read_body` to process the data in pieces via a block.
