### PR TITLE
Allow interface selection when multiple endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,8 @@ swift_client = SwiftClient.new(
   :auth_url => "https://auth.example.com/v3",
   :storage_url => "https://storage.example.com/v1/AUTH_account",
   :user_id => "user id",
-  :password => "password"
+  :password => "password",
+  :interface => "internal"
 )
 
 # OR

--- a/lib/swift_client.rb
+++ b/lib/swift_client.rb
@@ -333,7 +333,8 @@ class SwiftClient
 
     return unless swift_services.size == 1
 
-    swift_endpoints = swift_service["endpoints"].select { |endpoint| endpoint["interface"] == "public" }
+    interface = options[:interface] || "public"
+    swift_endpoints = swift_service["endpoints"].select { |endpoint| endpoint["interface"] == interface }
     swift_endpoint = swift_endpoints.first
 
     return unless swift_endpoints.size == 1


### PR DESCRIPTION
`interface` option to allow selection on non `public` endpoint