### PR TITLE
Update headers

### DIFF
--- a/lib/swift_client.rb
+++ b/lib/swift_client.rb
@@ -1,11 +1,10 @@
+require 'swift_client/version'
+require 'swift_client/null_cache'
 
-require "swift_client/version"
-require "swift_client/null_cache"
-
-require "httparty"
-require "mime-types"
-require "openssl"
-require "stringio"
+require 'httparty'
+require 'mime-types'
+require 'openssl'
+require 'stringio'
 
 class SwiftClient
   class AuthenticationError < StandardError; end
@@ -29,7 +28,7 @@ class SwiftClient
   attr_accessor :options, :auth_token, :storage_url, :cache_store
 
   def initialize(options = {})
-    raise(OptionError, "Setting expires_in connection wide is deprecated") if options[:expires_in]
+    raise(OptionError, 'Setting expires_in connection wide is deprecated') if options[:expires_in]
 
     self.options = options
     self.cache_store = options[:cache_store] || SwiftClient::NullCache.new
@@ -38,19 +37,19 @@ class SwiftClient
   end
 
   def head_account(options = {})
-    request :head, "/", options
+    request :head, '/', options
   end
 
   def post_account(headers = {}, options = {})
-    request :post, "/", options.merge(:headers => headers)
+    request :post, '/', options.merge(headers: headers)
   end
 
   def head_containers(options = {})
-    request :head, "/", options
+    request :head, '/', options
   end
 
   def get_containers(query = {}, options = {})
-    request :get, "/", options.merge(:query => query)
+    request :get, '/', options.merge(query: query)
   end
 
   def paginate_containers(query = {}, options = {}, &block)
@@ -60,7 +59,7 @@ class SwiftClient
   def get_container(container_name, query = {}, options = {})
     raise(EmptyNameError) if container_name.empty?
 
-    request :get, "/#{container_name}", options.merge(:query => query)
+    request :get, "/#{container_name}", options.merge(query: query)
   end
 
   def paginate_container(container_name, query = {}, options = {}, &block)
@@ -76,13 +75,13 @@ class SwiftClient
   def put_container(container_name, headers = {}, options = {})
     raise(EmptyNameError) if container_name.empty?
 
-    request :put, "/#{container_name}", options.merge(:headers => headers)
+    request :put, "/#{container_name}", options.merge(headers: headers)
   end
 
   def post_container(container_name, headers = {}, options = {})
     raise(EmptyNameError) if container_name.empty?
 
-    request :post, "/#{container_name}", options.merge(:headers => headers)
+    request :post, "/#{container_name}", options.merge(headers: headers)
   end
 
   def delete_container(container_name, options = {})
@@ -98,26 +97,26 @@ class SwiftClient
 
     extended_headers = (headers || {}).dup
 
-    unless find_header_key(extended_headers, "Content-Type")
-      extended_headers["Content-Type"] = mime_type.content_type if mime_type
-      extended_headers["Content-Type"] ||= "application/octet-stream"
+    unless find_header_key(extended_headers, 'Content-Type')
+      extended_headers['Content-Type'] = mime_type.content_type if mime_type
+      extended_headers['Content-Type'] ||= 'application/octet-stream'
     end
 
-    extended_headers["Transfer-Encoding"] = "chunked"
+    extended_headers['Transfer-Encoding'] = 'chunked'
 
-    request :put, "/#{container_name}/#{object_name}", options.merge(:body_stream => data_or_io.respond_to?(:read) ? data_or_io : StringIO.new(data_or_io), :headers => extended_headers)
+    request :put, "/#{container_name}/#{object_name}", options.merge(body_stream: data_or_io.respond_to?(:read) ? data_or_io : StringIO.new(data_or_io), headers: extended_headers)
   end
 
   def post_object(object_name, container_name, headers = {}, options = {})
     raise(EmptyNameError) if object_name.empty? || container_name.empty?
 
-    request :post, "/#{container_name}/#{object_name}", options.merge(:headers => headers)
+    request :post, "/#{container_name}/#{object_name}", options.merge(headers: headers)
   end
 
   def get_object(object_name, container_name, options = {}, &block)
     raise(EmptyNameError) if object_name.empty? || container_name.empty?
 
-    request(:get, "/#{container_name}/#{object_name}", options.merge(block ? { :stream_body => true } : {}), &block)
+    request(:get, "/#{container_name}/#{object_name}", options.merge(block ? { stream_body: true } : {}), &block)
   end
 
   def head_object(object_name, container_name, options = {})
@@ -135,7 +134,7 @@ class SwiftClient
   def get_objects(container_name, query = {}, options = {})
     raise(EmptyNameError) if container_name.empty?
 
-    request :get, "/#{container_name}", options.merge(:query => query)
+    request :get, "/#{container_name}", options.merge(query: query)
   end
 
   def paginate_objects(container_name, query = {}, options = {}, &block)
@@ -155,14 +154,14 @@ class SwiftClient
     expires = (Time.now + (opts[:expires_in] || 3600).to_i).to_i
     path = URI.parse("#{storage_url}/#{container_name}/#{object_name}").path
 
-    signature = OpenSSL::HMAC.hexdigest("sha1", options[:temp_url_key], "GET\n#{expires}\n#{path}")
+    signature = OpenSSL::HMAC.hexdigest('sha1', options[:temp_url_key], "GET\n#{expires}\n#{path}")
 
     "#{storage_url}/#{container_name}/#{object_name}?temp_url_sig=#{signature}&temp_url_expires=#{expires}"
   end
 
   def bulk_delete(items, options = {})
     items.each_slice(1_000) do |slice|
-      request :delete, "/?bulk-delete", options.merge(:body => slice.join("\n"), :headers => { "Content-Type" => "text/plain" })
+      request :delete, '/?bulk-delete', options.merge(body: slice.join("\n"), headers: { 'Content-Type' => 'text/plain' })
     end
 
     items
@@ -171,8 +170,8 @@ class SwiftClient
   private
 
   def cache_key
-    auth_keys = [:auth_url, :username, :access_key, :user_id, :user_domain, :user_domain_id, :domain_name,
-      :domain_id, :token, :project_id, :project_name, :project_domain_name, :project_domain_id, :tenant_name]
+    auth_keys = %i[auth_url username access_key user_id user_domain user_domain_id domain_name
+                   domain_id token project_id project_name project_domain_name project_domain_id tenant_name]
 
     auth_key = auth_keys.collect { |key| options[key] }.inspect
 
@@ -180,17 +179,17 @@ class SwiftClient
   end
 
   def find_header_key(headers, key)
-    headers.keys.detect { |k| k.downcase == key.downcase }
+    headers.keys.detect { |k| k.casecmp(key).zero? }
   end
 
   def request(method, path, opts = {}, &block)
     headers = (opts[:headers] || {}).dup
-    headers["X-Auth-Token"] = auth_token
-    headers["Accept"] = "application/json"
+    headers['X-Auth-Token'] = auth_token
+    headers['Accept'] = 'application/json'
 
     stream_pos = opts[:body_stream].pos if opts[:body_stream]
 
-    response = HTTParty.send(method, "#{storage_url}#{path}", opts.merge(:headers => headers), &block)
+    response = HTTParty.send(method, "#{storage_url}#{path}", opts.merge(headers: headers), &block)
 
     if response.code == 401
       authenticate
@@ -239,107 +238,107 @@ class SwiftClient
   end
 
   def authenticate_v1
-    [:auth_url, :username, :api_key].each do |key|
+    %i[auth_url username api_key].each do |key|
       raise(AuthenticationError, "#{key} missing") unless options[key]
     end
 
-    response = HTTParty.get(options[:auth_url], :headers => { "X-Auth-User" => options[:username], "X-Auth-Key" => options[:api_key] })
+    response = HTTParty.get(options[:auth_url], headers: { 'X-Auth-User' => options[:username], 'X-Auth-Key' => options[:api_key] })
 
     raise(AuthenticationError, "#{response.code}: #{response.message}") unless response.success?
 
-    set_authentication_details response.headers["X-Auth-Token"], options[:storage_url] || response.headers["X-Storage-Url"]
+    set_authentication_details response.headers['X-Auth-Token'], options[:storage_url] || response.headers['X-Storage-Url']
   end
 
   def authenticate_v2
-    [:auth_url, :storage_url].each do |key|
+    %i[auth_url storage_url].each do |key|
       raise(AuthenticationError, "#{key} missing") unless options[key]
     end
 
-    auth = { "auth" => {} }
+    auth = { 'auth' => {} }
 
     if options[:tenant_name]
-      auth["auth"]["tenantName"] = options[:tenant_name]
+      auth['auth']['tenantName'] = options[:tenant_name]
     else
-      raise AuthenticationError, "No tenant specified"
+      raise AuthenticationError, 'No tenant specified'
     end
 
     if options[:username] && options[:password]
-      auth["auth"]["passwordCredentials"] = { "username" => options[:username], "password" => options[:password] }
+      auth['auth']['passwordCredentials'] = { 'username' => options[:username], 'password' => options[:password] }
     elsif options[:access_key] && options[:secret_key]
-      auth["auth"]["apiAccessKeyCredentials"] = { "accessKey" => options[:access_key], "secretKey" => options[:secret_key] }
+      auth['auth']['apiAccessKeyCredentials'] = { 'accessKey' => options[:access_key], 'secretKey' => options[:secret_key] }
     else
-      raise AuthenticationError, "Unknown authentication method"
+      raise AuthenticationError, 'Unknown authentication method'
     end
 
-    response = HTTParty.post("#{options[:auth_url].gsub(/\/+$/, "")}/tokens", :body => JSON.dump(auth), :headers => { "Content-Type" => "application/json" })
+    response = HTTParty.post("#{options[:auth_url].gsub(%r{/+$}, '')}/tokens", body: JSON.dump(auth), headers: { 'Content-Type' => 'application/json' })
 
     raise(AuthenticationError, "#{response.code}: #{response.message}") unless response.success?
 
-    set_authentication_details response.parsed_response["access"]["token"]["id"], options[:storage_url]
+    set_authentication_details response.parsed_response['access']['token']['id'], options[:storage_url]
   end
 
   def authenticate_v3
-    raise(AuthenticationError, "auth_url missing") unless options[:auth_url]
-    raise(AuthenticationError, "username in combination with domain/domain_id is deprecated, please use user_domain/user_domain_id instead") if options[:username] && (options[:domain] || options[:domain_id]) && !options[:user_domain] && !options[:user_domain_id]
+    raise(AuthenticationError, 'auth_url missing') unless options[:auth_url]
+    raise(AuthenticationError, 'username in combination with domain/domain_id is deprecated, please use user_domain/user_domain_id instead') if options[:username] && (options[:domain] || options[:domain_id]) && !options[:user_domain] && !options[:user_domain_id]
 
-    auth = { "auth" => { "identity" => {} } }
+    auth = { 'auth' => { 'identity' => {} } }
 
     if options[:username] && options[:password] && (options[:user_domain] || options[:user_domain_id])
-      auth["auth"]["identity"]["methods"] = ["password"]
-      auth["auth"]["identity"]["password"] = { "user" => { "name" => options[:username], "password" => options[:password] } }
-      auth["auth"]["identity"]["password"]["user"]["domain"] = options[:user_domain] ? { "name" => options[:user_domain] } : { "id" => options[:user_domain_id] }
+      auth['auth']['identity']['methods'] = ['password']
+      auth['auth']['identity']['password'] = { 'user' => { 'name' => options[:username], 'password' => options[:password] } }
+      auth['auth']['identity']['password']['user']['domain'] = options[:user_domain] ? { 'name' => options[:user_domain] } : { 'id' => options[:user_domain_id] }
     elsif options[:user_id] && options[:password]
-      auth["auth"]["identity"]["methods"] = ["password"]
-      auth["auth"]["identity"]["password"] = { "user" => { "id" => options[:user_id], "password" => options[:password] } }
+      auth['auth']['identity']['methods'] = ['password']
+      auth['auth']['identity']['password'] = { 'user' => { 'id' => options[:user_id], 'password' => options[:password] } }
     elsif options[:token]
-      auth["auth"]["identity"]["methods"] = ["token"]
-      auth["auth"]["identity"]["token"] = { "id" => options[:token] }
+      auth['auth']['identity']['methods'] = ['token']
+      auth['auth']['identity']['token'] = { 'id' => options[:token] }
     else
-      raise AuthenticationError, "Unknown authentication method"
+      raise AuthenticationError, 'Unknown authentication method'
     end
 
     # handle project authentication scope
 
     if (options[:project_id] || options[:project_name]) && (options[:project_domain_name] || options[:project_domain_id])
-      auth["auth"]["scope"] = { "project" => { "domain" => {} } }
-      auth["auth"]["scope"]["project"]["name"] =  options[:project_name] if options[:project_name]
-      auth["auth"]["scope"]["project"]["id"] =  options[:project_id] if options[:project_id]
-      auth["auth"]["scope"]["project"]["domain"]["name"] = options[:project_domain_name] if options[:project_domain_name]
-      auth["auth"]["scope"]["project"]["domain"]["id"] = options[:project_domain_id] if options[:project_domain_id]
+      auth['auth']['scope'] = { 'project' => { 'domain' => {} } }
+      auth['auth']['scope']['project']['name'] = options[:project_name] if options[:project_name]
+      auth['auth']['scope']['project']['id'] = options[:project_id] if options[:project_id]
+      auth['auth']['scope']['project']['domain']['name'] = options[:project_domain_name] if options[:project_domain_name]
+      auth['auth']['scope']['project']['domain']['id'] = options[:project_domain_id] if options[:project_domain_id]
     end
 
     # handle domain authentication scope
 
     if options[:domain_name] || options[:domain_id]
-      auth["auth"]["scope"] = { "domain" => {} }
-      auth["auth"]["scope"]["domain"]["name"] = options[:domain_name] if options[:domain_name]
-      auth["auth"]["scope"]["domain"]["id"] = options[:domain_id] if options[:domain_id]
+      auth['auth']['scope'] = { 'domain' => {} }
+      auth['auth']['scope']['domain']['name'] = options[:domain_name] if options[:domain_name]
+      auth['auth']['scope']['domain']['id'] = options[:domain_id] if options[:domain_id]
     end
 
-    response = HTTParty.post("#{options[:auth_url].gsub(/\/+$/, "")}/auth/tokens", :body => JSON.dump(auth), :headers => { "Content-Type" => "application/json" })
+    response = HTTParty.post("#{options[:auth_url].gsub(%r{/+$}, '')}/auth/tokens", body: JSON.dump(auth), headers: { 'Content-Type' => 'application/json' })
 
     raise(AuthenticationError, "#{response.code}: #{response.message}") unless response.success?
 
     storage_url = options[:storage_url] || storage_url_from_v3_response(response)
 
-    raise(AuthenticationError, "storage_url missing") unless storage_url
+    raise(AuthenticationError, 'storage_url missing') unless storage_url
 
-    set_authentication_details response.headers["X-Subject-Token"], storage_url
+    set_authentication_details response.headers['X-Subject-Token'], storage_url
   end
 
   def storage_url_from_v3_response(response)
-    swift_services = Array(response.parsed_response["token"]["catalog"]).select { |service| service["type"] == "object-store" }
+    swift_services = Array(response.parsed_response['token']['catalog']).select { |service| service['type'] == 'object-store' }
     swift_service = swift_services.first
 
     return unless swift_services.size == 1
 
-    interface = options[:interface] || "public"
-    swift_endpoints = swift_service["endpoints"].select { |endpoint| endpoint["interface"] == interface }
+    interface = options[:interface] || 'public'
+    swift_endpoints = swift_service['endpoints'].select { |endpoint| endpoint['interface'] == interface }
     swift_endpoint = swift_endpoints.first
 
     return unless swift_endpoints.size == 1
 
-    swift_endpoint["url"]
+    swift_endpoint['url']
   end
 
   def paginate(method, *args, query, options)
@@ -348,13 +347,13 @@ class SwiftClient
     marker = nil
 
     loop do
-      response = send(method, *args, marker ? query.merge(:marker => marker) : query, options)
+      response = send(method, *args, marker ? query.merge(marker: marker) : query, options)
 
       return if response.parsed_response.empty?
 
       yield response
 
-      marker = response.parsed_response.last["name"]
+      marker = response.parsed_response.last['name']
     end
   end
 end

--- a/lib/swift_client.rb
+++ b/lib/swift_client.rb
@@ -125,6 +125,12 @@ class SwiftClient
     request :head, "/#{container_name}/#{object_name}", options
   end
 
+  def post_head(object_name, container_name, _headers = {}, options = {})
+    raise(EmptyNameError) if object_name.empty? || container_name.empty?
+
+    request :post, "/#{container_name}/#{object_name}", options.merge(headers: _headers)
+  end
+
   def delete_object(object_name, container_name, options = {})
     raise(EmptyNameError) if object_name.empty? || container_name.empty?
 

--- a/lib/swift_client.rb
+++ b/lib/swift_client.rb
@@ -1,10 +1,11 @@
-require 'swift_client/version'
-require 'swift_client/null_cache'
 
-require 'httparty'
-require 'mime-types'
-require 'openssl'
-require 'stringio'
+require "swift_client/version"
+require "swift_client/null_cache"
+
+require "httparty"
+require "mime-types"
+require "openssl"
+require "stringio"
 
 class SwiftClient
   class AuthenticationError < StandardError; end
@@ -28,7 +29,7 @@ class SwiftClient
   attr_accessor :options, :auth_token, :storage_url, :cache_store
 
   def initialize(options = {})
-    raise(OptionError, 'Setting expires_in connection wide is deprecated') if options[:expires_in]
+    raise(OptionError, "Setting expires_in connection wide is deprecated") if options[:expires_in]
 
     self.options = options
     self.cache_store = options[:cache_store] || SwiftClient::NullCache.new
@@ -37,19 +38,19 @@ class SwiftClient
   end
 
   def head_account(options = {})
-    request :head, '/', options
+    request :head, "/", options
   end
 
   def post_account(headers = {}, options = {})
-    request :post, '/', options.merge(headers: headers)
+    request :post, "/", options.merge(:headers => headers)
   end
 
   def head_containers(options = {})
-    request :head, '/', options
+    request :head, "/", options
   end
 
   def get_containers(query = {}, options = {})
-    request :get, '/', options.merge(query: query)
+    request :get, "/", options.merge(:query => query)
   end
 
   def paginate_containers(query = {}, options = {}, &block)
@@ -59,7 +60,7 @@ class SwiftClient
   def get_container(container_name, query = {}, options = {})
     raise(EmptyNameError) if container_name.empty?
 
-    request :get, "/#{container_name}", options.merge(query: query)
+    request :get, "/#{container_name}", options.merge(:query => query)
   end
 
   def paginate_container(container_name, query = {}, options = {}, &block)
@@ -75,13 +76,13 @@ class SwiftClient
   def put_container(container_name, headers = {}, options = {})
     raise(EmptyNameError) if container_name.empty?
 
-    request :put, "/#{container_name}", options.merge(headers: headers)
+    request :put, "/#{container_name}", options.merge(:headers => headers)
   end
 
   def post_container(container_name, headers = {}, options = {})
     raise(EmptyNameError) if container_name.empty?
 
-    request :post, "/#{container_name}", options.merge(headers: headers)
+    request :post, "/#{container_name}", options.merge(:headers => headers)
   end
 
   def delete_container(container_name, options = {})
@@ -97,26 +98,26 @@ class SwiftClient
 
     extended_headers = (headers || {}).dup
 
-    unless find_header_key(extended_headers, 'Content-Type')
-      extended_headers['Content-Type'] = mime_type.content_type if mime_type
-      extended_headers['Content-Type'] ||= 'application/octet-stream'
+    unless find_header_key(extended_headers, "Content-Type")
+      extended_headers["Content-Type"] = mime_type.content_type if mime_type
+      extended_headers["Content-Type"] ||= "application/octet-stream"
     end
 
-    extended_headers['Transfer-Encoding'] = 'chunked'
+    extended_headers["Transfer-Encoding"] = "chunked"
 
-    request :put, "/#{container_name}/#{object_name}", options.merge(body_stream: data_or_io.respond_to?(:read) ? data_or_io : StringIO.new(data_or_io), headers: extended_headers)
+    request :put, "/#{container_name}/#{object_name}", options.merge(:body_stream => data_or_io.respond_to?(:read) ? data_or_io : StringIO.new(data_or_io), :headers => extended_headers)
   end
 
   def post_object(object_name, container_name, headers = {}, options = {})
     raise(EmptyNameError) if object_name.empty? || container_name.empty?
 
-    request :post, "/#{container_name}/#{object_name}", options.merge(headers: headers)
+    request :post, "/#{container_name}/#{object_name}", options.merge(:headers => headers)
   end
 
   def get_object(object_name, container_name, options = {}, &block)
     raise(EmptyNameError) if object_name.empty? || container_name.empty?
 
-    request(:get, "/#{container_name}/#{object_name}", options.merge(block ? { stream_body: true } : {}), &block)
+    request(:get, "/#{container_name}/#{object_name}", options.merge(block ? { :stream_body => true } : {}), &block)
   end
 
   def head_object(object_name, container_name, options = {})
@@ -140,7 +141,7 @@ class SwiftClient
   def get_objects(container_name, query = {}, options = {})
     raise(EmptyNameError) if container_name.empty?
 
-    request :get, "/#{container_name}", options.merge(query: query)
+    request :get, "/#{container_name}", options.merge(:query => query)
   end
 
   def paginate_objects(container_name, query = {}, options = {}, &block)
@@ -160,14 +161,14 @@ class SwiftClient
     expires = (Time.now + (opts[:expires_in] || 3600).to_i).to_i
     path = URI.parse("#{storage_url}/#{container_name}/#{object_name}").path
 
-    signature = OpenSSL::HMAC.hexdigest('sha1', options[:temp_url_key], "GET\n#{expires}\n#{path}")
+    signature = OpenSSL::HMAC.hexdigest("sha1", options[:temp_url_key], "GET\n#{expires}\n#{path}")
 
     "#{storage_url}/#{container_name}/#{object_name}?temp_url_sig=#{signature}&temp_url_expires=#{expires}"
   end
 
   def bulk_delete(items, options = {})
     items.each_slice(1_000) do |slice|
-      request :delete, '/?bulk-delete', options.merge(body: slice.join("\n"), headers: { 'Content-Type' => 'text/plain' })
+      request :delete, "/?bulk-delete", options.merge(:body => slice.join("\n"), :headers => { "Content-Type" => "text/plain" })
     end
 
     items
@@ -176,8 +177,8 @@ class SwiftClient
   private
 
   def cache_key
-    auth_keys = %i[auth_url username access_key user_id user_domain user_domain_id domain_name
-                   domain_id token project_id project_name project_domain_name project_domain_id tenant_name]
+    auth_keys = [:auth_url, :username, :access_key, :user_id, :user_domain, :user_domain_id, :domain_name,
+      :domain_id, :token, :project_id, :project_name, :project_domain_name, :project_domain_id, :tenant_name]
 
     auth_key = auth_keys.collect { |key| options[key] }.inspect
 
@@ -185,17 +186,17 @@ class SwiftClient
   end
 
   def find_header_key(headers, key)
-    headers.keys.detect { |k| k.casecmp(key).zero? }
+    headers.keys.detect { |k| k.downcase == key.downcase }
   end
 
   def request(method, path, opts = {}, &block)
     headers = (opts[:headers] || {}).dup
-    headers['X-Auth-Token'] = auth_token
-    headers['Accept'] = 'application/json'
+    headers["X-Auth-Token"] = auth_token
+    headers["Accept"] = "application/json"
 
     stream_pos = opts[:body_stream].pos if opts[:body_stream]
 
-    response = HTTParty.send(method, "#{storage_url}#{path}", opts.merge(headers: headers), &block)
+    response = HTTParty.send(method, "#{storage_url}#{path}", opts.merge(:headers => headers), &block)
 
     if response.code == 401
       authenticate
@@ -244,107 +245,107 @@ class SwiftClient
   end
 
   def authenticate_v1
-    %i[auth_url username api_key].each do |key|
+    [:auth_url, :username, :api_key].each do |key|
       raise(AuthenticationError, "#{key} missing") unless options[key]
     end
 
-    response = HTTParty.get(options[:auth_url], headers: { 'X-Auth-User' => options[:username], 'X-Auth-Key' => options[:api_key] })
+    response = HTTParty.get(options[:auth_url], :headers => { "X-Auth-User" => options[:username], "X-Auth-Key" => options[:api_key] })
 
     raise(AuthenticationError, "#{response.code}: #{response.message}") unless response.success?
 
-    set_authentication_details response.headers['X-Auth-Token'], options[:storage_url] || response.headers['X-Storage-Url']
+    set_authentication_details response.headers["X-Auth-Token"], options[:storage_url] || response.headers["X-Storage-Url"]
   end
 
   def authenticate_v2
-    %i[auth_url storage_url].each do |key|
+    [:auth_url, :storage_url].each do |key|
       raise(AuthenticationError, "#{key} missing") unless options[key]
     end
 
-    auth = { 'auth' => {} }
+    auth = { "auth" => {} }
 
     if options[:tenant_name]
-      auth['auth']['tenantName'] = options[:tenant_name]
+      auth["auth"]["tenantName"] = options[:tenant_name]
     else
-      raise AuthenticationError, 'No tenant specified'
+      raise AuthenticationError, "No tenant specified"
     end
 
     if options[:username] && options[:password]
-      auth['auth']['passwordCredentials'] = { 'username' => options[:username], 'password' => options[:password] }
+      auth["auth"]["passwordCredentials"] = { "username" => options[:username], "password" => options[:password] }
     elsif options[:access_key] && options[:secret_key]
-      auth['auth']['apiAccessKeyCredentials'] = { 'accessKey' => options[:access_key], 'secretKey' => options[:secret_key] }
+      auth["auth"]["apiAccessKeyCredentials"] = { "accessKey" => options[:access_key], "secretKey" => options[:secret_key] }
     else
-      raise AuthenticationError, 'Unknown authentication method'
+      raise AuthenticationError, "Unknown authentication method"
     end
 
-    response = HTTParty.post("#{options[:auth_url].gsub(%r{/+$}, '')}/tokens", body: JSON.dump(auth), headers: { 'Content-Type' => 'application/json' })
+    response = HTTParty.post("#{options[:auth_url].gsub(/\/+$/, "")}/tokens", :body => JSON.dump(auth), :headers => { "Content-Type" => "application/json" })
 
     raise(AuthenticationError, "#{response.code}: #{response.message}") unless response.success?
 
-    set_authentication_details response.parsed_response['access']['token']['id'], options[:storage_url]
+    set_authentication_details response.parsed_response["access"]["token"]["id"], options[:storage_url]
   end
 
   def authenticate_v3
-    raise(AuthenticationError, 'auth_url missing') unless options[:auth_url]
-    raise(AuthenticationError, 'username in combination with domain/domain_id is deprecated, please use user_domain/user_domain_id instead') if options[:username] && (options[:domain] || options[:domain_id]) && !options[:user_domain] && !options[:user_domain_id]
+    raise(AuthenticationError, "auth_url missing") unless options[:auth_url]
+    raise(AuthenticationError, "username in combination with domain/domain_id is deprecated, please use user_domain/user_domain_id instead") if options[:username] && (options[:domain] || options[:domain_id]) && !options[:user_domain] && !options[:user_domain_id]
 
-    auth = { 'auth' => { 'identity' => {} } }
+    auth = { "auth" => { "identity" => {} } }
 
     if options[:username] && options[:password] && (options[:user_domain] || options[:user_domain_id])
-      auth['auth']['identity']['methods'] = ['password']
-      auth['auth']['identity']['password'] = { 'user' => { 'name' => options[:username], 'password' => options[:password] } }
-      auth['auth']['identity']['password']['user']['domain'] = options[:user_domain] ? { 'name' => options[:user_domain] } : { 'id' => options[:user_domain_id] }
+      auth["auth"]["identity"]["methods"] = ["password"]
+      auth["auth"]["identity"]["password"] = { "user" => { "name" => options[:username], "password" => options[:password] } }
+      auth["auth"]["identity"]["password"]["user"]["domain"] = options[:user_domain] ? { "name" => options[:user_domain] } : { "id" => options[:user_domain_id] }
     elsif options[:user_id] && options[:password]
-      auth['auth']['identity']['methods'] = ['password']
-      auth['auth']['identity']['password'] = { 'user' => { 'id' => options[:user_id], 'password' => options[:password] } }
+      auth["auth"]["identity"]["methods"] = ["password"]
+      auth["auth"]["identity"]["password"] = { "user" => { "id" => options[:user_id], "password" => options[:password] } }
     elsif options[:token]
-      auth['auth']['identity']['methods'] = ['token']
-      auth['auth']['identity']['token'] = { 'id' => options[:token] }
+      auth["auth"]["identity"]["methods"] = ["token"]
+      auth["auth"]["identity"]["token"] = { "id" => options[:token] }
     else
-      raise AuthenticationError, 'Unknown authentication method'
+      raise AuthenticationError, "Unknown authentication method"
     end
 
     # handle project authentication scope
 
     if (options[:project_id] || options[:project_name]) && (options[:project_domain_name] || options[:project_domain_id])
-      auth['auth']['scope'] = { 'project' => { 'domain' => {} } }
-      auth['auth']['scope']['project']['name'] = options[:project_name] if options[:project_name]
-      auth['auth']['scope']['project']['id'] = options[:project_id] if options[:project_id]
-      auth['auth']['scope']['project']['domain']['name'] = options[:project_domain_name] if options[:project_domain_name]
-      auth['auth']['scope']['project']['domain']['id'] = options[:project_domain_id] if options[:project_domain_id]
+      auth["auth"]["scope"] = { "project" => { "domain" => {} } }
+      auth["auth"]["scope"]["project"]["name"] =  options[:project_name] if options[:project_name]
+      auth["auth"]["scope"]["project"]["id"] =  options[:project_id] if options[:project_id]
+      auth["auth"]["scope"]["project"]["domain"]["name"] = options[:project_domain_name] if options[:project_domain_name]
+      auth["auth"]["scope"]["project"]["domain"]["id"] = options[:project_domain_id] if options[:project_domain_id]
     end
 
     # handle domain authentication scope
 
     if options[:domain_name] || options[:domain_id]
-      auth['auth']['scope'] = { 'domain' => {} }
-      auth['auth']['scope']['domain']['name'] = options[:domain_name] if options[:domain_name]
-      auth['auth']['scope']['domain']['id'] = options[:domain_id] if options[:domain_id]
+      auth["auth"]["scope"] = { "domain" => {} }
+      auth["auth"]["scope"]["domain"]["name"] = options[:domain_name] if options[:domain_name]
+      auth["auth"]["scope"]["domain"]["id"] = options[:domain_id] if options[:domain_id]
     end
 
-    response = HTTParty.post("#{options[:auth_url].gsub(%r{/+$}, '')}/auth/tokens", body: JSON.dump(auth), headers: { 'Content-Type' => 'application/json' })
+    response = HTTParty.post("#{options[:auth_url].gsub(/\/+$/, "")}/auth/tokens", :body => JSON.dump(auth), :headers => { "Content-Type" => "application/json" })
 
     raise(AuthenticationError, "#{response.code}: #{response.message}") unless response.success?
 
     storage_url = options[:storage_url] || storage_url_from_v3_response(response)
 
-    raise(AuthenticationError, 'storage_url missing') unless storage_url
+    raise(AuthenticationError, "storage_url missing") unless storage_url
 
-    set_authentication_details response.headers['X-Subject-Token'], storage_url
+    set_authentication_details response.headers["X-Subject-Token"], storage_url
   end
 
   def storage_url_from_v3_response(response)
-    swift_services = Array(response.parsed_response['token']['catalog']).select { |service| service['type'] == 'object-store' }
+    swift_services = Array(response.parsed_response["token"]["catalog"]).select { |service| service["type"] == "object-store" }
     swift_service = swift_services.first
 
     return unless swift_services.size == 1
 
-    interface = options[:interface] || 'public'
-    swift_endpoints = swift_service['endpoints'].select { |endpoint| endpoint['interface'] == interface }
+    interface = options[:interface] || "public"
+    swift_endpoints = swift_service["endpoints"].select { |endpoint| endpoint["interface"] == interface }
     swift_endpoint = swift_endpoints.first
 
     return unless swift_endpoints.size == 1
 
-    swift_endpoint['url']
+    swift_endpoint["url"]
   end
 
   def paginate(method, *args, query, options)
@@ -353,13 +354,13 @@ class SwiftClient
     marker = nil
 
     loop do
-      response = send(method, *args, marker ? query.merge(marker: marker) : query, options)
+      response = send(method, *args, marker ? query.merge(:marker => marker) : query, options)
 
       return if response.parsed_response.empty?
 
       yield response
 
-      marker = response.parsed_response.last['name']
+      marker = response.parsed_response.last["name"]
     end
   end
 end

--- a/test/swift_client_test.rb
+++ b/test/swift_client_test.rb
@@ -283,6 +283,12 @@ class SwiftClientTest < MiniTest::Test
     assert_equal 201, @swift_client.post_object('object', 'container', 'X-Object-Meta-Test' => 'Test').code
   end
 
+  def test_post_head
+    stub_request(:post, 'https://example.com/v1/AUTH_account/container/object').with(headers: { 'Accept' => 'application/json', 'X-Auth-Token' => 'Token', 'X-Delete-At' => '1553524860' }).to_return(status: 201, body: '', headers: {})
+
+    assert_equal 201, @swift_client.post_head('object', 'container', 'X-Delete-At' => '1553524860').code
+  end
+
   def test_get_object
     stub_request(:get, 'https://example.com/v1/AUTH_account/container/object').with(headers: { 'Accept' => 'application/json', 'X-Auth-Token' => 'Token' }).to_return(status: 200, body: 'Body', headers: {})
     block_res = 0

--- a/test/swift_client_test.rb
+++ b/test/swift_client_test.rb
@@ -1,4 +1,5 @@
-require File.expand_path('test_helper', __dir__)
+
+require File.expand_path("../test_helper", __FILE__)
 
 class MemoryCache
   def initialize
@@ -16,271 +17,271 @@ end
 
 class SwiftClientTest < MiniTest::Test
   def setup
-    stub_request(:get, 'https://example.com/auth/v1.0').with(headers: { 'X-Auth-Key' => 'secret', 'X-Auth-User' => 'account:username' }).to_return(status: 200, body: '', headers: { 'X-Auth-Token' => 'Token', 'X-Storage-Url' => 'https://example.com/v1/AUTH_account' })
+    stub_request(:get, "https://example.com/auth/v1.0").with(:headers => { "X-Auth-Key" => "secret", "X-Auth-User" => "account:username" }).to_return(:status => 200, :body => "", :headers => { "X-Auth-Token" => "Token", "X-Storage-Url" => "https://example.com/v1/AUTH_account" })
 
-    @swift_client = SwiftClient.new(auth_url: 'https://example.com/auth/v1.0', username: 'account:username', api_key: 'secret', temp_url_key: 'Temp url key')
+    @swift_client = SwiftClient.new(:auth_url => "https://example.com/auth/v1.0", :username => "account:username", :api_key => "secret", :temp_url_key => "Temp url key")
 
-    assert_equal 'Token', @swift_client.auth_token
-    assert_equal 'https://example.com/v1/AUTH_account', @swift_client.storage_url
+    assert_equal "Token", @swift_client.auth_token
+    assert_equal "https://example.com/v1/AUTH_account", @swift_client.storage_url
   end
 
   def test_authenticate_from_cache
     cache = MemoryCache.new
-    cache.set('swift_client:auth_token:49f42f2927701ba93a5bf9750da8fedfa197fa82', 'Cached token')
-    cache.set('swift_client:storage_url:49f42f2927701ba93a5bf9750da8fedfa197fa82', 'https://cache.example.com/v1/AUTH_account')
+    cache.set("swift_client:auth_token:49f42f2927701ba93a5bf9750da8fedfa197fa82", "Cached token")
+    cache.set("swift_client:storage_url:49f42f2927701ba93a5bf9750da8fedfa197fa82", "https://cache.example.com/v1/AUTH_account")
 
-    @swift_client = SwiftClient.new(auth_url: 'https://example.com/auth/v1.0', username: 'account:username', api_key: 'secret', temp_url_key: 'Temp url key', cache_store: cache)
+    @swift_client = SwiftClient.new(:auth_url => "https://example.com/auth/v1.0", :username => "account:username", :api_key => "secret", :temp_url_key => "Temp url key", :cache_store => cache)
 
-    assert_equal 'Cached token', @swift_client.auth_token
-    assert_equal 'https://cache.example.com/v1/AUTH_account', @swift_client.storage_url
+    assert_equal "Cached token", @swift_client.auth_token
+    assert_equal "https://cache.example.com/v1/AUTH_account", @swift_client.storage_url
 
     @swift_client.send(:authenticate) # Re-authenticate
 
-    assert_equal 'Token', @swift_client.auth_token
-    assert_equal 'https://example.com/v1/AUTH_account', @swift_client.storage_url
+    assert_equal "Token", @swift_client.auth_token
+    assert_equal "https://example.com/v1/AUTH_account", @swift_client.storage_url
   end
 
   def test_v3_authentication_unscoped_with_password
-    stub_request(:post, 'https://auth.example.com/v3/auth/tokens').with(body: JSON.dump('auth' => { 'identity' => { 'methods' => ['password'], 'password' => { 'user' => { 'name' => 'username', 'password' => 'secret', 'domain' => { 'name' => 'example.com' } } } } })).to_return(status: 200, body: JSON.dump('token' => '...'), headers: { 'X-Subject-Token' => 'Token', 'Content-Type' => 'application/json' })
+    stub_request(:post, "https://auth.example.com/v3/auth/tokens").with(:body => JSON.dump("auth" => { "identity" => { "methods" => ["password"], "password" => { "user" => { "name" => "username", "password" => "secret", "domain" => { "name" => "example.com" }}}}})).to_return(:status => 200, :body => JSON.dump("token" => "..."), :headers => { "X-Subject-Token" => "Token", "Content-Type" => "application/json" })
 
-    @swift_client = SwiftClient.new(storage_url: 'https://example.com/v1/AUTH_account', auth_url: 'https://auth.example.com/v3', username: 'username', user_domain: 'example.com', password: 'secret')
+    @swift_client = SwiftClient.new(:storage_url => "https://example.com/v1/AUTH_account", :auth_url => "https://auth.example.com/v3", :username => "username", :user_domain => "example.com", :password => "secret")
 
-    assert_equal 'Token', @swift_client.auth_token
-    assert_equal 'https://example.com/v1/AUTH_account', @swift_client.storage_url
+    assert_equal "Token", @swift_client.auth_token
+    assert_equal "https://example.com/v1/AUTH_account", @swift_client.storage_url
   end
 
   def test_v3_authentication_project_scoped_with_password
-    stub_request(:post, 'https://auth.example.com/v3/auth/tokens').with(body: JSON.dump('auth' => { 'identity' => { 'methods' => ['password'], 'password' => { 'user' => { 'name' => 'username', 'password' => 'secret', 'domain' => { 'name' => 'example.com' } } } }, 'scope' => { 'project' => { 'domain' => { 'id' => 'domain1' }, 'id' => 'project1' } } })).to_return(status: 200, body: JSON.dump('token' => '...'), headers: { 'X-Subject-Token' => 'Token', 'Content-Type' => 'application/json' })
+    stub_request(:post, "https://auth.example.com/v3/auth/tokens").with(:body => JSON.dump("auth" => { "identity" => { "methods" => ["password"], "password" => { "user" => { "name" => "username", "password" => "secret", "domain" => { "name" => "example.com" }}}}, "scope"=> { "project" => { "domain" => { "id" => "domain1" }, "id" => "project1" }}})).to_return(:status => 200, :body => JSON.dump("token" => "..."), :headers => { "X-Subject-Token" => "Token", "Content-Type" => "application/json" })
 
-    @swift_client = SwiftClient.new(storage_url: 'https://example.com/v1/AUTH_account', auth_url: 'https://auth.example.com/v3', username: 'username', user_domain: 'example.com', password: 'secret', project_id: 'project1', project_domain_id: 'domain1')
+    @swift_client = SwiftClient.new(:storage_url => "https://example.com/v1/AUTH_account", :auth_url => "https://auth.example.com/v3", :username => "username", :user_domain => "example.com", :password => "secret", :project_id => 'project1', :project_domain_id => 'domain1')
 
-    assert_equal 'Token', @swift_client.auth_token
-    assert_equal 'https://example.com/v1/AUTH_account', @swift_client.storage_url
+    assert_equal "Token", @swift_client.auth_token
+    assert_equal "https://example.com/v1/AUTH_account", @swift_client.storage_url
   end
 
   def test_v3_authentication_domain_scoped_with_password
-    stub_request(:post, 'https://auth.example.com/v3/auth/tokens').with(body: JSON.dump('auth' => { 'identity' => { 'methods' => ['password'], 'password' => { 'user' => { 'name' => 'username', 'password' => 'secret', 'domain' => { 'name' => 'example.com' } } } }, 'scope' => { 'domain' => { 'id' => 'domain1' } } })).to_return(status: 200, body: JSON.dump('token' => '...'), headers: { 'X-Subject-Token' => 'Token', 'Content-Type' => 'application/json' })
+    stub_request(:post, "https://auth.example.com/v3/auth/tokens").with(:body => JSON.dump("auth" => { "identity" => { "methods" => ["password"], "password" => { "user" => { "name" => "username", "password" => "secret", "domain" => { "name" => "example.com" }}}}, "scope"=> { "domain" => { "id" => "domain1" }}})).to_return(:status => 200, :body => JSON.dump("token" => "..."), :headers => { "X-Subject-Token" => "Token", "Content-Type" => "application/json" })
 
-    @swift_client = SwiftClient.new(storage_url: 'https://example.com/v1/AUTH_account', auth_url: 'https://auth.example.com/v3', username: 'username', user_domain: 'example.com', password: 'secret', domain_id: 'domain1')
+    @swift_client = SwiftClient.new(:storage_url => "https://example.com/v1/AUTH_account", :auth_url => "https://auth.example.com/v3", :username => "username", :user_domain => "example.com", :password => "secret", :domain_id => 'domain1')
 
-    assert_equal 'Token', @swift_client.auth_token
-    assert_equal 'https://example.com/v1/AUTH_account', @swift_client.storage_url
+    assert_equal "Token", @swift_client.auth_token
+    assert_equal "https://example.com/v1/AUTH_account", @swift_client.storage_url
   end
 
   def test_v3_authentication_storage_url_from_catalog
-    stub_request(:post, 'https://auth.example.com/v3/auth/tokens').with(body: JSON.dump('auth' => { 'identity' => { 'methods' => ['password'], 'password' => { 'user' => { 'name' => 'username', 'password' => 'secret', 'domain' => { 'name' => 'example.com' } } } } })).to_return(status: 200, body: JSON.dump('token' => { 'catalog' => [{ 'type' => 'object-store', 'endpoints' => [{ 'interface' => 'public', 'url' => 'https://example.com/v1/AUTH_account' }] }] }), headers: { 'X-Subject-Token' => 'Token', 'Content-Type' => 'application/json' })
+    stub_request(:post, "https://auth.example.com/v3/auth/tokens").with(:body => JSON.dump("auth" => { "identity" => { "methods" => ["password"], "password" => { "user" => { "name" => "username", "password" => "secret", "domain" => { "name" => "example.com" }}}}})).to_return(:status => 200, :body => JSON.dump("token" => { "catalog"=> [{ "type" => "object-store", "endpoints" => [{ "interface"=>"public", "url"=> "https://example.com/v1/AUTH_account" }] }] }), :headers => { "X-Subject-Token" => "Token", "Content-Type" => "application/json" })
 
-    @swift_client = SwiftClient.new(auth_url: 'https://auth.example.com/v3', username: 'username', user_domain: 'example.com', password: 'secret')
+    @swift_client = SwiftClient.new(:auth_url => "https://auth.example.com/v3", :username => "username", :user_domain => "example.com", :password => "secret")
 
-    assert_equal 'Token', @swift_client.auth_token
-    assert_equal 'https://example.com/v1/AUTH_account', @swift_client.storage_url
+    assert_equal "Token", @swift_client.auth_token
+    assert_equal "https://example.com/v1/AUTH_account", @swift_client.storage_url
   end
 
   def test_v3_authentication_storage_url_from_catalog_with_multiple_endpoints
-    stub_request(:post, 'https://auth.example.com/v3/auth/tokens').with(body: JSON.dump('auth' => { 'identity' => { 'methods' => ['password'], 'password' => { 'user' => { 'name' => 'username', 'password' => 'secret', 'domain' => { 'name' => 'example.com' } } } } })).to_return(status: 200, body: JSON.dump('token' => { 'catalog' => [{ 'type' => 'object-store', 'endpoints' => [{ 'interface' => 'public', 'url' => 'https://example.com/v1/AUTH_account' }, { 'interface' => 'internal', 'url' => 'https://example.com/v2/AUTH_account' }] }] }), headers: { 'X-Subject-Token' => 'Token', 'Content-Type' => 'application/json' })
+    stub_request(:post, "https://auth.example.com/v3/auth/tokens").with(:body => JSON.dump("auth" => { "identity" => { "methods" => ["password"], "password" => { "user" => { "name" => "username", "password" => "secret", "domain" => { "name" => "example.com" }}}}})).to_return(:status => 200, :body => JSON.dump("token" => { "catalog"=> [{ "type" => "object-store", "endpoints" => [{ "interface"=>"public", "url"=> "https://example.com/v1/AUTH_account" }, { "interface"=>"internal", "url"=> "https://example.com/v2/AUTH_account" }] }] }), :headers => { "X-Subject-Token" => "Token", "Content-Type" => "application/json" })
 
-    @swift_client = SwiftClient.new(auth_url: 'https://auth.example.com/v3', username: 'username', user_domain: 'example.com', password: 'secret', interface: 'internal')
+    @swift_client = SwiftClient.new(:auth_url => "https://auth.example.com/v3", :username => "username", :user_domain => "example.com", :password => "secret", :interface => "internal")
 
-    assert_equal 'Token', @swift_client.auth_token
-    assert_equal 'https://example.com/v2/AUTH_account', @swift_client.storage_url
+    assert_equal "Token", @swift_client.auth_token
+    assert_equal "https://example.com/v2/AUTH_account", @swift_client.storage_url
   end
 
   def test_v3_authentication_without_storage_url_and_multiple_swifts
-    stub_request(:post, 'https://auth.example.com/v3/auth/tokens').with(body: JSON.dump('auth' => { 'identity' => { 'methods' => ['password'], 'password' => { 'user' => { 'name' => 'username', 'password' => 'secret', 'domain' => { 'name' => 'example.com' } } } } })).to_return(status: 200, body: JSON.dump('token' => { 'catalog' => [{ 'type' => 'object-store', 'endpoints' => [{ 'interface' => 'public', 'url' => 'https://example.com/v1/AUTH_account' }] }, { 'type' => 'object-store', 'endpoints' => [{ 'interface' => 'public', 'url' => 'https://example.com/v1/AUTH_account' }] }] }), headers: { 'X-Subject-Token' => 'Token', 'Content-Type' => 'application/json' })
+    stub_request(:post, "https://auth.example.com/v3/auth/tokens").with(:body => JSON.dump("auth" => { "identity" => { "methods" => ["password"], "password" => { "user" => { "name" => "username", "password" => "secret", "domain" => { "name" => "example.com" }}}}})).to_return(:status => 200, :body => JSON.dump("token" => { "catalog"=> [{ "type" => "object-store", "endpoints" => [{ "interface"=>"public", "url"=> "https://example.com/v1/AUTH_account" }] }, { "type" => "object-store", "endpoints" => [{ "interface"=>"public", "url"=> "https://example.com/v1/AUTH_account" }] }] }), :headers => { "X-Subject-Token" => "Token", "Content-Type" => "application/json" })
 
     assert_raises SwiftClient::AuthenticationError do
-      SwiftClient.new auth_url: 'https://auth.example.com/v3', username: 'username', user_domain: 'example.com', password: 'secret'
+      SwiftClient.new :auth_url => "https://auth.example.com/v3", :username => "username", :user_domain => "example.com", :password => "secret"
     end
   end
 
   def test_v3_authentication_without_storage_url_and_multiple_endpoints
-    stub_request(:post, 'https://auth.example.com/v3/auth/tokens').with(body: JSON.dump('auth' => { 'identity' => { 'methods' => ['password'], 'password' => { 'user' => { 'name' => 'username', 'password' => 'secret', 'domain' => { 'name' => 'example.com' } } } } })).to_return(status: 200, body: JSON.dump('token' => { 'catalog' => [{ 'type' => 'object-store', 'endpoints' => [{ 'interface' => 'public', 'url' => 'https://first.example.com/v1/AUTH_account' }, { 'interface' => 'public', 'url' => 'https://second.example.com/v1/AUTH_account' }] }] }), headers: { 'X-Subject-Token' => 'Token', 'Content-Type' => 'application/json' })
+    stub_request(:post, "https://auth.example.com/v3/auth/tokens").with(:body => JSON.dump("auth" => { "identity" => { "methods" => ["password"], "password" => { "user" => { "name" => "username", "password" => "secret", "domain" => { "name" => "example.com" }}}}})).to_return(:status => 200, :body => JSON.dump("token" => { "catalog"=> [{ "type" => "object-store", "endpoints" => [{ "interface"=>"public", "url"=> "https://first.example.com/v1/AUTH_account" }, { "interface"=>"public", "url"=> "https://second.example.com/v1/AUTH_account" }] }] }), :headers => { "X-Subject-Token" => "Token", "Content-Type" => "application/json" })
 
     assert_raises SwiftClient::AuthenticationError do
-      SwiftClient.new auth_url: 'https://auth.example.com/v3', username: 'username', user_domain: 'example.com', password: 'secret'
+      SwiftClient.new :auth_url => "https://auth.example.com/v3", :username => "username", :user_domain => "example.com", :password => "secret"
     end
   end
 
   def test_v3_authentication_with_token
-    stub_request(:post, 'https://auth.example.com/v3/auth/tokens').with(body: JSON.dump('auth' => { 'identity' => { 'methods' => ['token'], 'token' => { 'id' => 'Token' } } })).to_return(status: 200, body: JSON.dump('token' => '...'), headers: { 'X-Subject-Token' => 'Token', 'Content-Type' => 'application/json' })
+    stub_request(:post, "https://auth.example.com/v3/auth/tokens").with(:body => JSON.dump("auth" => { "identity" => { "methods" => ["token"], "token" => { "id" => "Token" }}})).to_return(:status => 200, :body => JSON.dump("token" => "..."), :headers => { "X-Subject-Token" => "Token", "Content-Type" => "application/json" })
 
-    @swift_client = SwiftClient.new(storage_url: 'https://example.com/v1/AUTH_account', auth_url: 'https://auth.example.com/v3', token: 'Token')
+    @swift_client = SwiftClient.new(:storage_url => "https://example.com/v1/AUTH_account", :auth_url => "https://auth.example.com/v3", :token => "Token")
 
-    assert_equal 'Token', @swift_client.auth_token
-    assert_equal 'https://example.com/v1/AUTH_account', @swift_client.storage_url
+    assert_equal "Token", @swift_client.auth_token
+    assert_equal "https://example.com/v1/AUTH_account", @swift_client.storage_url
   end
 
   def test_v3_authentication_username_domain_deprecation
     assert_raises SwiftClient::AuthenticationError do
-      SwiftClient.new auth_url: 'https://auth.example.com/v3', username: 'username', domain: 'example.com', password: 'secret'
+      SwiftClient.new :auth_url => "https://auth.example.com/v3", :username => "username", :domain => "example.com", :password => "secret"
     end
   end
 
   def test_v2_authentication_with_password
-    stub_request(:post, 'https://auth.example.com/v2.0/tokens').with(body: JSON.dump('auth' => { 'tenantName' => 'Tenant', 'passwordCredentials' => { 'username' => 'Username', :password => 'Password' } })).to_return(status: 200, body: JSON.dump('access' => { 'token' => { 'id' => 'Token' } }), headers: { 'Content-Type' => 'application/json' })
+    stub_request(:post, "https://auth.example.com/v2.0/tokens").with(:body => JSON.dump("auth" => { "tenantName" => "Tenant", "passwordCredentials" => { "username" => "Username", :password => "Password"  }})).to_return(:status => 200, :body => JSON.dump("access" => { "token" => { "id" => "Token" }}), :headers => { "Content-Type" => "application/json" })
 
-    @swift_client = SwiftClient.new(storage_url: 'https://example.com/v1/AUTH_account', auth_url: 'https://auth.example.com/v2.0', tenant_name: 'Tenant', username: 'Username', password: 'Password')
+    @swift_client = SwiftClient.new(:storage_url => "https://example.com/v1/AUTH_account", :auth_url => "https://auth.example.com/v2.0", :tenant_name => "Tenant", :username => "Username", :password => "Password")
 
-    assert_equal 'Token', @swift_client.auth_token
-    assert_equal 'https://example.com/v1/AUTH_account', @swift_client.storage_url
+    assert_equal "Token", @swift_client.auth_token
+    assert_equal "https://example.com/v1/AUTH_account", @swift_client.storage_url
   end
 
   def test_v2_authentication_with_key
-    stub_request(:post, 'https://auth.example.com/v2.0/tokens').with(body: JSON.dump('auth' => { 'tenantName' => 'Tenant', 'apiAccessKeyCredentials' => { 'accessKey' => 'AccessKey', :secretKey => 'SecretKey' } })).to_return(status: 200, body: JSON.dump('access' => { 'token' => { 'id' => 'Token' } }), headers: { 'Content-Type' => 'application/json' })
+    stub_request(:post, "https://auth.example.com/v2.0/tokens").with(:body => JSON.dump("auth" => { "tenantName" => "Tenant", "apiAccessKeyCredentials" => { "accessKey" => "AccessKey", :secretKey => "SecretKey"  }})).to_return(:status => 200, :body => JSON.dump("access" => { "token" => { "id" => "Token" }}), :headers => { "Content-Type" => "application/json" })
 
-    @swift_client = SwiftClient.new(storage_url: 'https://example.com/v1/AUTH_account', auth_url: 'https://auth.example.com/v2.0', tenant_name: 'Tenant', access_key: 'AccessKey', secret_key: 'SecretKey')
+    @swift_client = SwiftClient.new(:storage_url => "https://example.com/v1/AUTH_account", :auth_url => "https://auth.example.com/v2.0", :tenant_name => "Tenant", :access_key => "AccessKey", :secret_key => "SecretKey")
 
-    assert_equal 'Token', @swift_client.auth_token
-    assert_equal 'https://example.com/v1/AUTH_account', @swift_client.storage_url
+    assert_equal "Token", @swift_client.auth_token
+    assert_equal "https://example.com/v1/AUTH_account", @swift_client.storage_url
   end
 
   def test_storage_url
-    stub_request(:get, 'https://example.com/auth/v1.0').with(headers: { 'X-Auth-Key' => 'secret', 'X-Auth-User' => 'account:username' }).to_return(status: 200, body: '', headers: { 'X-Auth-Token' => 'Token', 'X-Storage-Url' => 'https://example.com/v1/AUTH_account' })
+    stub_request(:get, "https://example.com/auth/v1.0").with(:headers => { "X-Auth-Key" => "secret", "X-Auth-User" => "account:username" }).to_return(:status => 200, :body => "", :headers => { "X-Auth-Token" => "Token", "X-Storage-Url" => "https://example.com/v1/AUTH_account" })
 
-    @swift_client = SwiftClient.new(auth_url: 'https://example.com/auth/v1.0', username: 'account:username', api_key: 'secret', storage_url: 'https://storage-url.com/path')
+    @swift_client = SwiftClient.new(:auth_url => "https://example.com/auth/v1.0", :username => "account:username", :api_key => "secret", :storage_url => "https://storage-url.com/path")
 
-    assert_equal 'Token', @swift_client.auth_token
-    assert_equal 'https://storage-url.com/path', @swift_client.storage_url
+    assert_equal "Token", @swift_client.auth_token
+    assert_equal "https://storage-url.com/path", @swift_client.storage_url
   end
 
   def test_head_account
-    stub_request(:head, 'https://example.com/v1/AUTH_account/').with(headers: { 'Accept' => 'application/json', 'X-Auth-Token' => 'Token' }).to_return(status: 204, body: '', headers: { 'Content-Type' => 'application/json' })
+    stub_request(:head, "https://example.com/v1/AUTH_account/").with(:headers => { "Accept" => "application/json", "X-Auth-Token" => "Token" }).to_return(:status => 204, :body => "", :headers => { "Content-Type" => "application/json" })
 
     assert 204, @swift_client.head_account.code
   end
 
   def test_post_account
-    stub_request(:post, 'https://example.com/v1/AUTH_account/').with(headers: { 'Accept' => 'application/json', 'X-Auth-Token' => 'Token', 'X-Account-Meta-Test' => 'Test' }).to_return(status: 204, body: '', headers: { 'Content-Type' => 'application/json' })
+    stub_request(:post, "https://example.com/v1/AUTH_account/").with(:headers => { "Accept" => "application/json", "X-Auth-Token" => "Token", "X-Account-Meta-Test" => "Test" }).to_return(:status => 204, :body => "", :headers => { "Content-Type" => "application/json" })
 
-    assert_equal 204, @swift_client.post_account('X-Account-Meta-Test' => 'Test').code
+    assert_equal 204, @swift_client.post_account("X-Account-Meta-Test" => "Test").code
   end
 
   def test_head_containers
-    stub_request(:head, 'https://example.com/v1/AUTH_account/').with(headers: { 'Accept' => 'application/json', 'X-Auth-Token' => 'Token' }).to_return(status: 204, body: '', headers: { 'Content-Type' => 'application/json' })
+    stub_request(:head, "https://example.com/v1/AUTH_account/").with(:headers => { "Accept" => "application/json", "X-Auth-Token" => "Token" }).to_return(:status => 204, :body => "", :headers => { "Content-Type" => "application/json" })
 
     assert 204, @swift_client.head_containers.code
   end
 
   def test_get_containers
     containers = [
-      { 'count' => 1, 'bytes' => 1, 'name' => 'container-1' },
-      { 'count' => 1, 'bytes' => 1, 'name' => 'container-2' }
+      { "count" => 1, "bytes" => 1, "name" => "container-1" },
+      { "count" => 1, "bytes" => 1, "name" => "container-2" }
     ]
 
-    stub_request(:get, 'https://example.com/v1/AUTH_account/').with(headers: { 'Accept' => 'application/json', 'X-Auth-Token' => 'Token' }).to_return(status: 200, body: JSON.dump(containers), headers: { 'Content-Type' => 'application/json' })
+    stub_request(:get, "https://example.com/v1/AUTH_account/").with(:headers => { "Accept" => "application/json", "X-Auth-Token" => "Token" }).to_return(:status => 200, :body => JSON.dump(containers), :headers => { "Content-Type" => "application/json" })
 
     assert_equal containers, @swift_client.get_containers.parsed_response
   end
 
   def test_bulk_delete
     objects = [
-      'container1/object1',
-      'container1/object2',
-      'container2/object1'
+      "container1/object1",
+      "container1/object2",
+      "container2/object1"
     ]
 
-    stub_request(:delete, 'https://example.com/v1/AUTH_account/?bulk-delete').with(body: objects.join("\n"), headers: { 'Content-Type' => 'text/plain', 'X-Auth-Token' => 'Token' }).to_return(status: 200, body: '', headers: { 'Content-Type' => 'application/json' })
+    stub_request(:delete, "https://example.com/v1/AUTH_account/?bulk-delete").with(:body => objects.join("\n"), :headers => { "Content-Type" => "text/plain", "X-Auth-Token" => "Token" }).to_return(:status => 200,:body => "", :headers => { "Content-Type" => "application/json" })
 
     assert @swift_client.bulk_delete(objects)
   end
 
   def test_paginate_containers
     containers = [
-      { 'count' => 1, 'bytes' => 1, 'name' => 'container-1' },
-      { 'count' => 1, 'bytes' => 1, 'name' => 'container-2' },
-      { 'count' => 1, 'bytes' => 1, 'name' => 'container-3' }
+      { "count" => 1, "bytes" => 1, "name" => "container-1" },
+      { "count" => 1, "bytes" => 1, "name" => "container-2" },
+      { "count" => 1, "bytes" => 1, "name" => "container-3" }
     ]
 
-    stub_request(:get, 'https://example.com/v1/AUTH_account/?limit=2').with(headers: { 'Accept' => 'application/json', 'X-Auth-Token' => 'Token' }).to_return(status: 200, body: JSON.dump(containers[0..1]), headers: { 'Content-Type' => 'application/json' })
-    stub_request(:get, 'https://example.com/v1/AUTH_account/?limit=2&marker=container-2').with(headers: { 'Accept' => 'application/json', 'X-Auth-Token' => 'Token' }).to_return(status: 200, body: JSON.dump(containers[2..3]), headers: { 'Content-Type' => 'application/json' })
-    stub_request(:get, 'https://example.com/v1/AUTH_account/?limit=2&marker=container-3').with(headers: { 'Accept' => 'application/json', 'X-Auth-Token' => 'Token' }).to_return(status: 200, body: JSON.dump([]), headers: { 'Content-Type' => 'application/json' })
+    stub_request(:get, "https://example.com/v1/AUTH_account/?limit=2").with(:headers => { "Accept" => "application/json", "X-Auth-Token" => "Token" }).to_return(:status => 200, :body => JSON.dump(containers[0 .. 1]), :headers => { "Content-Type" => "application/json" })
+    stub_request(:get, "https://example.com/v1/AUTH_account/?limit=2&marker=container-2").with(:headers => { "Accept" => "application/json", "X-Auth-Token" => "Token" }).to_return(:status => 200, :body => JSON.dump(containers[2 .. 3]), :headers => { "Content-Type" => "application/json" })
+    stub_request(:get, "https://example.com/v1/AUTH_account/?limit=2&marker=container-3").with(:headers => { "Accept" => "application/json", "X-Auth-Token" => "Token" }).to_return(:status => 200, :body => JSON.dump([]), :headers => { "Content-Type" => "application/json" })
 
-    assert_equal containers, @swift_client.paginate_containers(limit: 2).collect(&:parsed_response).flatten
+    assert_equal containers, @swift_client.paginate_containers(:limit => 2).collect(&:parsed_response).flatten
   end
 
   def test_get_container
     objects = [
-      { 'hash' => 'Hash', 'last_modified' => 'Last modified', 'bytes' => 1, 'name' => 'object-2', 'content_type' => 'Content type' },
-      { 'hash' => 'Hash', 'last_modified' => 'Last modified', 'bytes' => 1, 'name' => 'object-3', 'content_type' => 'Content type' }
+      { "hash" => "Hash", "last_modified" => "Last modified", "bytes" => 1, "name" => "object-2", "content_type" => "Content type" },
+      { "hash" => "Hash", "last_modified" => "Last modified", "bytes" => 1, "name" => "object-3", "content_type" => "Content type" }
     ]
 
-    stub_request(:get, 'https://example.com/v1/AUTH_account/container-1?limit=2&marker=object-2').with(headers: { 'Accept' => 'application/json', 'X-Auth-Token' => 'Token' }).to_return(status: 200, body: JSON.dump(objects), headers: { 'Content-Type' => 'application/json' })
+    stub_request(:get, "https://example.com/v1/AUTH_account/container-1?limit=2&marker=object-2").with(:headers => { "Accept" => "application/json", "X-Auth-Token" => "Token" }).to_return(:status => 200, :body => JSON.dump(objects), :headers => { "Content-Type" => "application/json" })
 
-    assert_equal objects, @swift_client.get_container('container-1', limit: 2, marker: 'object-2').parsed_response
+    assert_equal objects, @swift_client.get_container("container-1", :limit => 2, :marker => "object-2").parsed_response
   end
 
   def test_paginate_container
     objects = [
-      { 'hash' => 'Hash', 'last_modified' => 'Last modified', 'bytes' => 1, 'name' => 'object-1', 'content_type' => 'Content type' },
-      { 'hash' => 'Hash', 'last_modified' => 'Last modified', 'bytes' => 1, 'name' => 'object-2', 'content_type' => 'Content type' },
-      { 'hash' => 'Hash', 'last_modified' => 'Last modified', 'bytes' => 1, 'name' => 'object-3', 'content_type' => 'Content type' }
+      { "hash" => "Hash", "last_modified" => "Last modified", "bytes" => 1, "name" => "object-1", "content_type" => "Content type" },
+      { "hash" => "Hash", "last_modified" => "Last modified", "bytes" => 1, "name" => "object-2", "content_type" => "Content type" },
+      { "hash" => "Hash", "last_modified" => "Last modified", "bytes" => 1, "name" => "object-3", "content_type" => "Content type" },
     ]
 
-    stub_request(:get, 'https://example.com/v1/AUTH_account/container-1?limit=2').with(headers: { 'Accept' => 'application/json', 'X-Auth-Token' => 'Token' }).to_return(status: 200, body: JSON.dump(objects[0..1]), headers: { 'Content-Type' => 'application/json' })
-    stub_request(:get, 'https://example.com/v1/AUTH_account/container-1?limit=2&marker=object-2').with(headers: { 'Accept' => 'application/json', 'X-Auth-Token' => 'Token' }).to_return(status: 200, body: JSON.dump(objects[2..3]), headers: { 'Content-Type' => 'application/json' })
-    stub_request(:get, 'https://example.com/v1/AUTH_account/container-1?limit=2&marker=object-3').with(headers: { 'Accept' => 'application/json', 'X-Auth-Token' => 'Token' }).to_return(status: 200, body: JSON.dump([]), headers: { 'Content-Type' => 'application/json' })
+    stub_request(:get, "https://example.com/v1/AUTH_account/container-1?limit=2").with(:headers => { "Accept" => "application/json", "X-Auth-Token" => "Token" }).to_return(:status => 200, :body => JSON.dump(objects[0 .. 1]), :headers => { "Content-Type" => "application/json" })
+    stub_request(:get, "https://example.com/v1/AUTH_account/container-1?limit=2&marker=object-2").with(:headers => { "Accept" => "application/json", "X-Auth-Token" => "Token" }).to_return(:status => 200, :body => JSON.dump(objects[2 .. 3]), :headers => { "Content-Type" => "application/json" })
+    stub_request(:get, "https://example.com/v1/AUTH_account/container-1?limit=2&marker=object-3").with(:headers => { "Accept" => "application/json", "X-Auth-Token" => "Token" }).to_return(:status => 200, :body => JSON.dump([]), :headers => { "Content-Type" => "application/json" })
 
-    assert_equal objects, @swift_client.paginate_container('container-1', limit: 2).collect(&:parsed_response).flatten
+    assert_equal objects, @swift_client.paginate_container("container-1", :limit => 2).collect(&:parsed_response).flatten
   end
 
   def test_head_container
-    stub_request(:head, 'https://example.com/v1/AUTH_account/container-1').with(headers: { 'Accept' => 'application/json', 'X-Auth-Token' => 'Token' }).to_return(status: 204, body: '', headers: { 'Content-Type' => 'application/json' })
+    stub_request(:head, "https://example.com/v1/AUTH_account/container-1").with(:headers => { "Accept" => "application/json", "X-Auth-Token" => "Token" }).to_return(:status => 204, :body => "", :headers => { "Content-Type" => "application/json" })
 
-    assert 204, @swift_client.head_container('container-1').code
+    assert 204, @swift_client.head_container("container-1").code
   end
 
   def test_put_container
-    stub_request(:put, 'https://example.com/v1/AUTH_account/container').with(headers: { 'Accept' => 'application/json', 'X-Auth-Token' => 'Token', 'X-Container-Read' => '.r:*' }).to_return(status: 201, body: '', headers: {})
+    stub_request(:put, "https://example.com/v1/AUTH_account/container").with(:headers => { "Accept" => "application/json", "X-Auth-Token" => "Token", "X-Container-Read" => ".r:*" }).to_return(:status => 201, :body => "", :headers => {})
 
-    assert_equal 201, @swift_client.put_container('container', 'X-Container-Read' => '.r:*').code
+    assert_equal 201, @swift_client.put_container("container", "X-Container-Read" => ".r:*").code
   end
 
   def test_post_container
-    stub_request(:post, 'https://example.com/v1/AUTH_account/container').with(headers: { 'Accept' => 'application/json', 'X-Auth-Token' => 'Token', 'X-Container-Read' => '.r:*' }).to_return(status: 204, body: '', headers: {})
+    stub_request(:post, "https://example.com/v1/AUTH_account/container").with(:headers => { "Accept" => "application/json", "X-Auth-Token" => "Token", "X-Container-Read" => ".r:*" }).to_return(:status => 204, :body => "", :headers => {})
 
-    assert_equal 204, @swift_client.post_container('container', 'X-Container-Read' => '.r:*').code
+    assert_equal 204, @swift_client.post_container("container", "X-Container-Read" => ".r:*").code
   end
 
   def test_delete_container
-    stub_request(:delete, 'https://example.com/v1/AUTH_account/container').with(headers: { 'Accept' => 'application/json', 'X-Auth-Token' => 'Token' }).to_return(status: 204, body: '', headers: {})
+    stub_request(:delete, "https://example.com/v1/AUTH_account/container").with(:headers => { "Accept" => "application/json", "X-Auth-Token" => "Token" }).to_return(:status => 204, :body => "", :headers => {})
 
-    assert_equal 204, @swift_client.delete_container('container').code
+    assert_equal 204, @swift_client.delete_container("container").code
   end
 
   def test_put_object
-    stub_request(:put, 'https://example.com/v1/AUTH_account/container/object').with(body: 'data', headers: { 'Transfer-Encoding' => 'chunked', 'Content-Type' => 'application/octet-stream', 'Accept' => 'application/json', 'X-Auth-Token' => 'Token', 'X-Object-Meta-Test' => 'Test' }).to_return(status: 201, body: '', headers: {})
+    stub_request(:put, "https://example.com/v1/AUTH_account/container/object").with(:body => "data", :headers => { "Transfer-Encoding" => "chunked", "Content-Type" => "application/octet-stream", "Accept" => "application/json", "X-Auth-Token" => "Token", "X-Object-Meta-Test" => "Test" }).to_return(:status => 201, :body => "", :headers => {})
 
-    assert_equal 201, @swift_client.put_object('object', 'data', 'container', 'X-Object-Meta-Test' => 'Test').code
+    assert_equal 201, @swift_client.put_object("object", "data", "container", "X-Object-Meta-Test" => "Test").code
   end
 
   def test_put_object_with_renewed_authorization
-    stub_request(:put, 'https://example.com/v1/AUTH_account/container/object').with(body: 'data', headers: { 'Transfer-Encoding' => 'chunked', 'Content-Type' => 'application/octet-stream', 'Accept' => 'application/json', 'X-Auth-Token' => 'Token' }).to_return({ status: 401, body: '', headers: {} }, status: 201, body: '', headers: {})
+    stub_request(:put, "https://example.com/v1/AUTH_account/container/object").with(:body => "data", :headers => { "Transfer-Encoding" => "chunked", "Content-Type" => "application/octet-stream", "Accept" => "application/json", "X-Auth-Token" => "Token" }).to_return({ :status => 401, :body => "", :headers => {}}, { :status => 201, :body => "", :headers => {}})
 
-    assert_equal 201, @swift_client.put_object('object', 'data', 'container').code
+    assert_equal 201, @swift_client.put_object("object", "data", "container").code
   end
 
   def test_put_object_without_mime_type
-    stub_request(:put, 'https://example.com/v1/AUTH_account/container/object.jpg').with(body: 'data', headers: { 'Transfer-Encoding' => 'chunked', 'Accept' => 'application/json', 'Content-Type' => 'image/jpeg', 'X-Auth-Token' => 'Token', 'X-Object-Meta-Test' => 'Test' }).to_return(status: 201, body: '', headers: {})
+    stub_request(:put, "https://example.com/v1/AUTH_account/container/object.jpg").with(:body => "data", :headers => { "Transfer-Encoding" => "chunked", "Accept" => "application/json", "Content-Type" => "image/jpeg", "X-Auth-Token" => "Token", "X-Object-Meta-Test" => "Test" }).to_return(:status => 201, :body => "", :headers => {})
 
-    assert_equal 201, @swift_client.put_object('object.jpg', 'data', 'container', 'X-Object-Meta-Test' => 'Test').code
+    assert_equal 201, @swift_client.put_object("object.jpg", "data", "container", "X-Object-Meta-Test" => "Test").code
   end
 
   def test_put_object_with_mime_type
-    stub_request(:put, 'https://example.com/v1/AUTH_account/container/object.jpg').with(body: 'data', headers: { 'Transfer-Encoding' => 'chunked', 'Accept' => 'application/json', 'Content-Type' => 'content/type', 'X-Auth-Token' => 'Token', 'X-Object-Meta-Test' => 'Test' }).to_return(status: 201, body: '', headers: {})
+    stub_request(:put, "https://example.com/v1/AUTH_account/container/object.jpg").with(:body => "data", :headers => { "Transfer-Encoding" => "chunked", "Accept" => "application/json", "Content-Type" => "content/type", "X-Auth-Token" => "Token", "X-Object-Meta-Test" => "Test" }).to_return(:status => 201, :body => "", :headers => {})
 
-    assert_equal 201, @swift_client.put_object('object.jpg', 'data', 'container', 'X-Object-Meta-Test' => 'Test', 'Content-Type' => 'content/type').code
+    assert_equal 201, @swift_client.put_object("object.jpg", "data", "container", "X-Object-Meta-Test" => "Test", "Content-Type" => "content/type").code
   end
 
   def test_put_object_with_io
-    stub_request(:put, 'https://example.com/v1/AUTH_account/container/object').with(body: 'data', headers: { 'Transfer-Encoding' => 'chunked', 'Accept' => 'application/json', 'X-Auth-Token' => 'Token', 'X-Object-Meta-Test' => 'Test' }).to_return(status: 201, body: '', headers: {})
+    stub_request(:put, "https://example.com/v1/AUTH_account/container/object").with(:body => "data", :headers => { "Transfer-Encoding" => "chunked", "Accept" => "application/json", "X-Auth-Token" => "Token", "X-Object-Meta-Test" => "Test" }).to_return(:status => 201, :body => "", :headers => {})
 
-    assert_equal 201, @swift_client.put_object('object', StringIO.new('data'), 'container', 'X-Object-Meta-Test' => 'Test').code
+    assert_equal 201, @swift_client.put_object("object", StringIO.new("data"), "container", "X-Object-Meta-Test" => "Test").code
   end
 
   def test_post_object
-    stub_request(:post, 'https://example.com/v1/AUTH_account/container/object').with(headers: { 'Accept' => 'application/json', 'X-Auth-Token' => 'Token', 'X-Object-Meta-Test' => 'Test' }).to_return(status: 201, body: '', headers: {})
+    stub_request(:post, "https://example.com/v1/AUTH_account/container/object").with(:headers => { "Accept" => "application/json", "X-Auth-Token" => "Token", "X-Object-Meta-Test" => "Test" }).to_return(:status => 201, :body => "", :headers => {})
 
-    assert_equal 201, @swift_client.post_object('object', 'container', 'X-Object-Meta-Test' => 'Test').code
+    assert_equal 201, @swift_client.post_object("object", "container", "X-Object-Meta-Test" => "Test").code
   end
 
   def test_post_head
@@ -290,15 +291,15 @@ class SwiftClientTest < MiniTest::Test
   end
 
   def test_get_object
-    stub_request(:get, 'https://example.com/v1/AUTH_account/container/object').with(headers: { 'Accept' => 'application/json', 'X-Auth-Token' => 'Token' }).to_return(status: 200, body: 'Body', headers: {})
+    stub_request(:get, "https://example.com/v1/AUTH_account/container/object").with(:headers => { "Accept" => "application/json", "X-Auth-Token" => "Token" }).to_return(:status => 200, :body => "Body", :headers => {})
     block_res = 0
 
-    large_body = 'Body' * 16_384
-    stub_request(:get, 'https://example.com/v1/AUTH_account/container/large_object').with(headers: { 'Accept' => 'application/json', 'X-Auth-Token' => 'Token' }).to_return(status: 200, body: large_body, headers: {})
+    large_body = "Body" * 16384
+    stub_request(:get, "https://example.com/v1/AUTH_account/container/large_object").with(:headers => { "Accept" => "application/json", "X-Auth-Token" => "Token" }).to_return(:status => 200, :body => large_body, :headers => {})
 
-    assert_equal 'Body', @swift_client.get_object('object', 'container').body
+    assert_equal "Body", @swift_client.get_object("object", "container").body
 
-    @swift_client.get_object('large_object', 'container') do |chunk|
+    @swift_client.get_object("large_object", "container") do |chunk|
       block_res += chunk.length
     end
 
@@ -306,61 +307,61 @@ class SwiftClientTest < MiniTest::Test
   end
 
   def test_head_object
-    stub_request(:head, 'https://example.com/v1/AUTH_account/container/object').with(headers: { 'Accept' => 'application/json', 'X-Auth-Token' => 'Token' }).to_return(status: 200, body: '', headers: {})
+    stub_request(:head, "https://example.com/v1/AUTH_account/container/object").with(:headers => { "Accept" => "application/json", "X-Auth-Token" => "Token" }).to_return(:status => 200, :body => "", :headers => {})
 
-    assert_equal 200, @swift_client.head_object('object', 'container').code
+    assert_equal 200, @swift_client.head_object("object", "container").code
   end
 
   def test_delete_object
-    stub_request(:delete, 'https://example.com/v1/AUTH_account/container/object').with(headers: { 'Accept' => 'application/json', 'X-Auth-Token' => 'Token' }).to_return(status: 204, body: '', headers: {})
+    stub_request(:delete, "https://example.com/v1/AUTH_account/container/object").with(:headers => { "Accept" => "application/json", "X-Auth-Token" => "Token" }).to_return(:status => 204, :body => "", :headers => {})
 
-    assert_equal 204, @swift_client.delete_object('object', 'container').code
+    assert_equal 204, @swift_client.delete_object("object", "container").code
   end
 
   def test_get_objects
     objects = [
-      { 'hash' => 'Hash', 'last_modified' => 'Last modified', 'bytes' => 1, 'name' => 'object-2', 'content_type' => 'Content type' },
-      { 'hash' => 'Hash', 'last_modified' => 'Last modified', 'bytes' => 1, 'name' => 'object-3', 'content_type' => 'Content type' }
+      { "hash" => "Hash", "last_modified" => "Last modified", "bytes" => 1, "name" => "object-2", "content_type" => "Content type" },
+      { "hash" => "Hash", "last_modified" => "Last modified", "bytes" => 1, "name" => "object-3", "content_type" => "Content type" }
     ]
 
-    stub_request(:get, 'https://example.com/v1/AUTH_account/container-1?limit=2&marker=object-2').with(headers: { 'Accept' => 'application/json', 'X-Auth-Token' => 'Token' }).to_return(status: 200, body: JSON.dump(objects), headers: { 'Content-Type' => 'application/json' })
+    stub_request(:get, "https://example.com/v1/AUTH_account/container-1?limit=2&marker=object-2").with(:headers => { "Accept" => "application/json", "X-Auth-Token" => "Token" }).to_return(:status => 200, :body => JSON.dump(objects), :headers => { "Content-Type" => "application/json" })
 
-    assert_equal objects, @swift_client.get_objects('container-1', limit: 2, marker: 'object-2').parsed_response
+    assert_equal objects, @swift_client.get_objects("container-1", :limit => 2, :marker => "object-2").parsed_response
   end
 
   def test_paginate_objects
     objects = [
-      { 'hash' => 'Hash', 'last_modified' => 'Last modified', 'bytes' => 1, 'name' => 'object-1', 'content_type' => 'Content type' },
-      { 'hash' => 'Hash', 'last_modified' => 'Last modified', 'bytes' => 1, 'name' => 'object-2', 'content_type' => 'Content type' },
-      { 'hash' => 'Hash', 'last_modified' => 'Last modified', 'bytes' => 1, 'name' => 'object-3', 'content_type' => 'Content type' }
+      { "hash" => "Hash", "last_modified" => "Last modified", "bytes" => 1, "name" => "object-1", "content_type" => "Content type" },
+      { "hash" => "Hash", "last_modified" => "Last modified", "bytes" => 1, "name" => "object-2", "content_type" => "Content type" },
+      { "hash" => "Hash", "last_modified" => "Last modified", "bytes" => 1, "name" => "object-3", "content_type" => "Content type" }
     ]
 
-    stub_request(:get, 'https://example.com/v1/AUTH_account/container-1?limit=2').with(headers: { 'Accept' => 'application/json', 'X-Auth-Token' => 'Token' }).to_return(status: 200, body: JSON.dump(objects[0..1]), headers: { 'Content-Type' => 'application/json' })
-    stub_request(:get, 'https://example.com/v1/AUTH_account/container-1?limit=2&marker=object-2').with(headers: { 'Accept' => 'application/json', 'X-Auth-Token' => 'Token' }).to_return(status: 200, body: JSON.dump(objects[2..3]), headers: { 'Content-Type' => 'application/json' })
-    stub_request(:get, 'https://example.com/v1/AUTH_account/container-1?limit=2&marker=object-3').with(headers: { 'Accept' => 'application/json', 'X-Auth-Token' => 'Token' }).to_return(status: 200, body: JSON.dump([]), headers: { 'Content-Type' => 'application/json' })
+    stub_request(:get, "https://example.com/v1/AUTH_account/container-1?limit=2").with(:headers => { "Accept" => "application/json", "X-Auth-Token" => "Token" }).to_return(:status => 200, :body => JSON.dump(objects[0 .. 1]), :headers => { "Content-Type" => "application/json" })
+    stub_request(:get, "https://example.com/v1/AUTH_account/container-1?limit=2&marker=object-2").with(:headers => { "Accept" => "application/json", "X-Auth-Token" => "Token" }).to_return(:status => 200, :body => JSON.dump(objects[2 .. 3]), :headers => { "Content-Type" => "application/json" })
+    stub_request(:get, "https://example.com/v1/AUTH_account/container-1?limit=2&marker=object-3").with(:headers => { "Accept" => "application/json", "X-Auth-Token" => "Token" }).to_return(:status => 200, :body => JSON.dump([]), :headers => { "Content-Type" => "application/json" })
 
-    assert_equal objects, @swift_client.paginate_objects('container-1', limit: 2).collect(&:parsed_response).flatten
+    assert_equal objects, @swift_client.paginate_objects("container-1", :limit => 2).collect(&:parsed_response).flatten
   end
 
   def test_not_found
-    stub_request(:get, 'https://example.com/v1/AUTH_account/container/object').with(headers: { 'Accept' => 'application/json', 'X-Auth-Token' => 'Token' }).to_return(status: [404, 'Not Found'], body: '', headers: { 'Content-Type' => 'application/json' })
+    stub_request(:get, "https://example.com/v1/AUTH_account/container/object").with(:headers => { "Accept" => "application/json", "X-Auth-Token" => "Token" }).to_return(:status => [404, "Not Found"], :body => "", :headers => { "Content-Type" => "application/json" })
 
     begin
-      @swift_client.get_object('object', 'container')
+      @swift_client.get_object("object", "container")
     rescue SwiftClient::ResponseError => e
       assert_equal 404, e.code
-      assert_equal 'Not Found', e.message
+      assert_equal "Not Found", e.message
     end
   end
 
   def test_public_url
-    assert_equal 'https://example.com/v1/AUTH_account/container/object', @swift_client.public_url('object', 'container')
+    assert_equal "https://example.com/v1/AUTH_account/container/object", @swift_client.public_url("object", "container")
   end
 
   def test_temp_url
     Time.expects(:now).at_least_once.returns(1_000_000)
 
-    assert @swift_client.temp_url('object', 'container') =~ %r{https://example.com/v1/AUTH_account/container/object\?temp_url_sig=[a-f0-9]{40}&temp_url_expires=1003600}
-    assert @swift_client.temp_url('object', 'container', expires_in: 86_400) =~ %r{https://example.com/v1/AUTH_account/container/object\?temp_url_sig=[a-f0-9]{40}&temp_url_expires=1086400}
+    assert @swift_client.temp_url("object", "container") =~ %r{https://example.com/v1/AUTH_account/container/object\?temp_url_sig=[a-f0-9]{40}&temp_url_expires=1003600}
+    assert @swift_client.temp_url("object", "container", :expires_in => 86400) =~ %r{https://example.com/v1/AUTH_account/container/object\?temp_url_sig=[a-f0-9]{40}&temp_url_expires=1086400}
   end
 end

--- a/test/swift_client_test.rb
+++ b/test/swift_client_test.rb
@@ -1,5 +1,4 @@
-
-require File.expand_path("../test_helper", __FILE__)
+require File.expand_path('test_helper', __dir__)
 
 class MemoryCache
   def initialize
@@ -17,283 +16,283 @@ end
 
 class SwiftClientTest < MiniTest::Test
   def setup
-    stub_request(:get, "https://example.com/auth/v1.0").with(:headers => { "X-Auth-Key" => "secret", "X-Auth-User" => "account:username" }).to_return(:status => 200, :body => "", :headers => { "X-Auth-Token" => "Token", "X-Storage-Url" => "https://example.com/v1/AUTH_account" })
+    stub_request(:get, 'https://example.com/auth/v1.0').with(headers: { 'X-Auth-Key' => 'secret', 'X-Auth-User' => 'account:username' }).to_return(status: 200, body: '', headers: { 'X-Auth-Token' => 'Token', 'X-Storage-Url' => 'https://example.com/v1/AUTH_account' })
 
-    @swift_client = SwiftClient.new(:auth_url => "https://example.com/auth/v1.0", :username => "account:username", :api_key => "secret", :temp_url_key => "Temp url key")
+    @swift_client = SwiftClient.new(auth_url: 'https://example.com/auth/v1.0', username: 'account:username', api_key: 'secret', temp_url_key: 'Temp url key')
 
-    assert_equal "Token", @swift_client.auth_token
-    assert_equal "https://example.com/v1/AUTH_account", @swift_client.storage_url
+    assert_equal 'Token', @swift_client.auth_token
+    assert_equal 'https://example.com/v1/AUTH_account', @swift_client.storage_url
   end
 
   def test_authenticate_from_cache
     cache = MemoryCache.new
-    cache.set("swift_client:auth_token:49f42f2927701ba93a5bf9750da8fedfa197fa82", "Cached token")
-    cache.set("swift_client:storage_url:49f42f2927701ba93a5bf9750da8fedfa197fa82", "https://cache.example.com/v1/AUTH_account")
+    cache.set('swift_client:auth_token:49f42f2927701ba93a5bf9750da8fedfa197fa82', 'Cached token')
+    cache.set('swift_client:storage_url:49f42f2927701ba93a5bf9750da8fedfa197fa82', 'https://cache.example.com/v1/AUTH_account')
 
-    @swift_client = SwiftClient.new(:auth_url => "https://example.com/auth/v1.0", :username => "account:username", :api_key => "secret", :temp_url_key => "Temp url key", :cache_store => cache)
+    @swift_client = SwiftClient.new(auth_url: 'https://example.com/auth/v1.0', username: 'account:username', api_key: 'secret', temp_url_key: 'Temp url key', cache_store: cache)
 
-    assert_equal "Cached token", @swift_client.auth_token
-    assert_equal "https://cache.example.com/v1/AUTH_account", @swift_client.storage_url
+    assert_equal 'Cached token', @swift_client.auth_token
+    assert_equal 'https://cache.example.com/v1/AUTH_account', @swift_client.storage_url
 
     @swift_client.send(:authenticate) # Re-authenticate
 
-    assert_equal "Token", @swift_client.auth_token
-    assert_equal "https://example.com/v1/AUTH_account", @swift_client.storage_url
+    assert_equal 'Token', @swift_client.auth_token
+    assert_equal 'https://example.com/v1/AUTH_account', @swift_client.storage_url
   end
 
   def test_v3_authentication_unscoped_with_password
-    stub_request(:post, "https://auth.example.com/v3/auth/tokens").with(:body => JSON.dump("auth" => { "identity" => { "methods" => ["password"], "password" => { "user" => { "name" => "username", "password" => "secret", "domain" => { "name" => "example.com" }}}}})).to_return(:status => 200, :body => JSON.dump("token" => "..."), :headers => { "X-Subject-Token" => "Token", "Content-Type" => "application/json" })
+    stub_request(:post, 'https://auth.example.com/v3/auth/tokens').with(body: JSON.dump('auth' => { 'identity' => { 'methods' => ['password'], 'password' => { 'user' => { 'name' => 'username', 'password' => 'secret', 'domain' => { 'name' => 'example.com' } } } } })).to_return(status: 200, body: JSON.dump('token' => '...'), headers: { 'X-Subject-Token' => 'Token', 'Content-Type' => 'application/json' })
 
-    @swift_client = SwiftClient.new(:storage_url => "https://example.com/v1/AUTH_account", :auth_url => "https://auth.example.com/v3", :username => "username", :user_domain => "example.com", :password => "secret")
+    @swift_client = SwiftClient.new(storage_url: 'https://example.com/v1/AUTH_account', auth_url: 'https://auth.example.com/v3', username: 'username', user_domain: 'example.com', password: 'secret')
 
-    assert_equal "Token", @swift_client.auth_token
-    assert_equal "https://example.com/v1/AUTH_account", @swift_client.storage_url
+    assert_equal 'Token', @swift_client.auth_token
+    assert_equal 'https://example.com/v1/AUTH_account', @swift_client.storage_url
   end
 
   def test_v3_authentication_project_scoped_with_password
-    stub_request(:post, "https://auth.example.com/v3/auth/tokens").with(:body => JSON.dump("auth" => { "identity" => { "methods" => ["password"], "password" => { "user" => { "name" => "username", "password" => "secret", "domain" => { "name" => "example.com" }}}}, "scope"=> { "project" => { "domain" => { "id" => "domain1" }, "id" => "project1" }}})).to_return(:status => 200, :body => JSON.dump("token" => "..."), :headers => { "X-Subject-Token" => "Token", "Content-Type" => "application/json" })
+    stub_request(:post, 'https://auth.example.com/v3/auth/tokens').with(body: JSON.dump('auth' => { 'identity' => { 'methods' => ['password'], 'password' => { 'user' => { 'name' => 'username', 'password' => 'secret', 'domain' => { 'name' => 'example.com' } } } }, 'scope' => { 'project' => { 'domain' => { 'id' => 'domain1' }, 'id' => 'project1' } } })).to_return(status: 200, body: JSON.dump('token' => '...'), headers: { 'X-Subject-Token' => 'Token', 'Content-Type' => 'application/json' })
 
-    @swift_client = SwiftClient.new(:storage_url => "https://example.com/v1/AUTH_account", :auth_url => "https://auth.example.com/v3", :username => "username", :user_domain => "example.com", :password => "secret", :project_id => 'project1', :project_domain_id => 'domain1')
+    @swift_client = SwiftClient.new(storage_url: 'https://example.com/v1/AUTH_account', auth_url: 'https://auth.example.com/v3', username: 'username', user_domain: 'example.com', password: 'secret', project_id: 'project1', project_domain_id: 'domain1')
 
-    assert_equal "Token", @swift_client.auth_token
-    assert_equal "https://example.com/v1/AUTH_account", @swift_client.storage_url
+    assert_equal 'Token', @swift_client.auth_token
+    assert_equal 'https://example.com/v1/AUTH_account', @swift_client.storage_url
   end
 
   def test_v3_authentication_domain_scoped_with_password
-    stub_request(:post, "https://auth.example.com/v3/auth/tokens").with(:body => JSON.dump("auth" => { "identity" => { "methods" => ["password"], "password" => { "user" => { "name" => "username", "password" => "secret", "domain" => { "name" => "example.com" }}}}, "scope"=> { "domain" => { "id" => "domain1" }}})).to_return(:status => 200, :body => JSON.dump("token" => "..."), :headers => { "X-Subject-Token" => "Token", "Content-Type" => "application/json" })
+    stub_request(:post, 'https://auth.example.com/v3/auth/tokens').with(body: JSON.dump('auth' => { 'identity' => { 'methods' => ['password'], 'password' => { 'user' => { 'name' => 'username', 'password' => 'secret', 'domain' => { 'name' => 'example.com' } } } }, 'scope' => { 'domain' => { 'id' => 'domain1' } } })).to_return(status: 200, body: JSON.dump('token' => '...'), headers: { 'X-Subject-Token' => 'Token', 'Content-Type' => 'application/json' })
 
-    @swift_client = SwiftClient.new(:storage_url => "https://example.com/v1/AUTH_account", :auth_url => "https://auth.example.com/v3", :username => "username", :user_domain => "example.com", :password => "secret", :domain_id => 'domain1')
+    @swift_client = SwiftClient.new(storage_url: 'https://example.com/v1/AUTH_account', auth_url: 'https://auth.example.com/v3', username: 'username', user_domain: 'example.com', password: 'secret', domain_id: 'domain1')
 
-    assert_equal "Token", @swift_client.auth_token
-    assert_equal "https://example.com/v1/AUTH_account", @swift_client.storage_url
+    assert_equal 'Token', @swift_client.auth_token
+    assert_equal 'https://example.com/v1/AUTH_account', @swift_client.storage_url
   end
 
   def test_v3_authentication_storage_url_from_catalog
-    stub_request(:post, "https://auth.example.com/v3/auth/tokens").with(:body => JSON.dump("auth" => { "identity" => { "methods" => ["password"], "password" => { "user" => { "name" => "username", "password" => "secret", "domain" => { "name" => "example.com" }}}}})).to_return(:status => 200, :body => JSON.dump("token" => { "catalog"=> [{ "type" => "object-store", "endpoints" => [{ "interface"=>"public", "url"=> "https://example.com/v1/AUTH_account" }] }] }), :headers => { "X-Subject-Token" => "Token", "Content-Type" => "application/json" })
+    stub_request(:post, 'https://auth.example.com/v3/auth/tokens').with(body: JSON.dump('auth' => { 'identity' => { 'methods' => ['password'], 'password' => { 'user' => { 'name' => 'username', 'password' => 'secret', 'domain' => { 'name' => 'example.com' } } } } })).to_return(status: 200, body: JSON.dump('token' => { 'catalog' => [{ 'type' => 'object-store', 'endpoints' => [{ 'interface' => 'public', 'url' => 'https://example.com/v1/AUTH_account' }] }] }), headers: { 'X-Subject-Token' => 'Token', 'Content-Type' => 'application/json' })
 
-    @swift_client = SwiftClient.new(:auth_url => "https://auth.example.com/v3", :username => "username", :user_domain => "example.com", :password => "secret")
+    @swift_client = SwiftClient.new(auth_url: 'https://auth.example.com/v3', username: 'username', user_domain: 'example.com', password: 'secret')
 
-    assert_equal "Token", @swift_client.auth_token
-    assert_equal "https://example.com/v1/AUTH_account", @swift_client.storage_url
+    assert_equal 'Token', @swift_client.auth_token
+    assert_equal 'https://example.com/v1/AUTH_account', @swift_client.storage_url
   end
 
   def test_v3_authentication_storage_url_from_catalog_with_multiple_endpoints
-    stub_request(:post, "https://auth.example.com/v3/auth/tokens").with(:body => JSON.dump("auth" => { "identity" => { "methods" => ["password"], "password" => { "user" => { "name" => "username", "password" => "secret", "domain" => { "name" => "example.com" }}}}})).to_return(:status => 200, :body => JSON.dump("token" => { "catalog"=> [{ "type" => "object-store", "endpoints" => [{ "interface"=>"public", "url"=> "https://example.com/v1/AUTH_account" }, { "interface"=>"internal", "url"=> "https://example.com/v2/AUTH_account" }] }] }), :headers => { "X-Subject-Token" => "Token", "Content-Type" => "application/json" })
+    stub_request(:post, 'https://auth.example.com/v3/auth/tokens').with(body: JSON.dump('auth' => { 'identity' => { 'methods' => ['password'], 'password' => { 'user' => { 'name' => 'username', 'password' => 'secret', 'domain' => { 'name' => 'example.com' } } } } })).to_return(status: 200, body: JSON.dump('token' => { 'catalog' => [{ 'type' => 'object-store', 'endpoints' => [{ 'interface' => 'public', 'url' => 'https://example.com/v1/AUTH_account' }, { 'interface' => 'internal', 'url' => 'https://example.com/v2/AUTH_account' }] }] }), headers: { 'X-Subject-Token' => 'Token', 'Content-Type' => 'application/json' })
 
-    @swift_client = SwiftClient.new(:auth_url => "https://auth.example.com/v3", :username => "username", :user_domain => "example.com", :password => "secret", :interface => "internal")
+    @swift_client = SwiftClient.new(auth_url: 'https://auth.example.com/v3', username: 'username', user_domain: 'example.com', password: 'secret', interface: 'internal')
 
-    assert_equal "Token", @swift_client.auth_token
-    assert_equal "https://example.com/v2/AUTH_account", @swift_client.storage_url
+    assert_equal 'Token', @swift_client.auth_token
+    assert_equal 'https://example.com/v2/AUTH_account', @swift_client.storage_url
   end
 
   def test_v3_authentication_without_storage_url_and_multiple_swifts
-    stub_request(:post, "https://auth.example.com/v3/auth/tokens").with(:body => JSON.dump("auth" => { "identity" => { "methods" => ["password"], "password" => { "user" => { "name" => "username", "password" => "secret", "domain" => { "name" => "example.com" }}}}})).to_return(:status => 200, :body => JSON.dump("token" => { "catalog"=> [{ "type" => "object-store", "endpoints" => [{ "interface"=>"public", "url"=> "https://example.com/v1/AUTH_account" }] }, { "type" => "object-store", "endpoints" => [{ "interface"=>"public", "url"=> "https://example.com/v1/AUTH_account" }] }] }), :headers => { "X-Subject-Token" => "Token", "Content-Type" => "application/json" })
+    stub_request(:post, 'https://auth.example.com/v3/auth/tokens').with(body: JSON.dump('auth' => { 'identity' => { 'methods' => ['password'], 'password' => { 'user' => { 'name' => 'username', 'password' => 'secret', 'domain' => { 'name' => 'example.com' } } } } })).to_return(status: 200, body: JSON.dump('token' => { 'catalog' => [{ 'type' => 'object-store', 'endpoints' => [{ 'interface' => 'public', 'url' => 'https://example.com/v1/AUTH_account' }] }, { 'type' => 'object-store', 'endpoints' => [{ 'interface' => 'public', 'url' => 'https://example.com/v1/AUTH_account' }] }] }), headers: { 'X-Subject-Token' => 'Token', 'Content-Type' => 'application/json' })
 
     assert_raises SwiftClient::AuthenticationError do
-      SwiftClient.new :auth_url => "https://auth.example.com/v3", :username => "username", :user_domain => "example.com", :password => "secret"
+      SwiftClient.new auth_url: 'https://auth.example.com/v3', username: 'username', user_domain: 'example.com', password: 'secret'
     end
   end
 
   def test_v3_authentication_without_storage_url_and_multiple_endpoints
-    stub_request(:post, "https://auth.example.com/v3/auth/tokens").with(:body => JSON.dump("auth" => { "identity" => { "methods" => ["password"], "password" => { "user" => { "name" => "username", "password" => "secret", "domain" => { "name" => "example.com" }}}}})).to_return(:status => 200, :body => JSON.dump("token" => { "catalog"=> [{ "type" => "object-store", "endpoints" => [{ "interface"=>"public", "url"=> "https://first.example.com/v1/AUTH_account" }, { "interface"=>"public", "url"=> "https://second.example.com/v1/AUTH_account" }] }] }), :headers => { "X-Subject-Token" => "Token", "Content-Type" => "application/json" })
+    stub_request(:post, 'https://auth.example.com/v3/auth/tokens').with(body: JSON.dump('auth' => { 'identity' => { 'methods' => ['password'], 'password' => { 'user' => { 'name' => 'username', 'password' => 'secret', 'domain' => { 'name' => 'example.com' } } } } })).to_return(status: 200, body: JSON.dump('token' => { 'catalog' => [{ 'type' => 'object-store', 'endpoints' => [{ 'interface' => 'public', 'url' => 'https://first.example.com/v1/AUTH_account' }, { 'interface' => 'public', 'url' => 'https://second.example.com/v1/AUTH_account' }] }] }), headers: { 'X-Subject-Token' => 'Token', 'Content-Type' => 'application/json' })
 
     assert_raises SwiftClient::AuthenticationError do
-      SwiftClient.new :auth_url => "https://auth.example.com/v3", :username => "username", :user_domain => "example.com", :password => "secret"
+      SwiftClient.new auth_url: 'https://auth.example.com/v3', username: 'username', user_domain: 'example.com', password: 'secret'
     end
   end
 
   def test_v3_authentication_with_token
-    stub_request(:post, "https://auth.example.com/v3/auth/tokens").with(:body => JSON.dump("auth" => { "identity" => { "methods" => ["token"], "token" => { "id" => "Token" }}})).to_return(:status => 200, :body => JSON.dump("token" => "..."), :headers => { "X-Subject-Token" => "Token", "Content-Type" => "application/json" })
+    stub_request(:post, 'https://auth.example.com/v3/auth/tokens').with(body: JSON.dump('auth' => { 'identity' => { 'methods' => ['token'], 'token' => { 'id' => 'Token' } } })).to_return(status: 200, body: JSON.dump('token' => '...'), headers: { 'X-Subject-Token' => 'Token', 'Content-Type' => 'application/json' })
 
-    @swift_client = SwiftClient.new(:storage_url => "https://example.com/v1/AUTH_account", :auth_url => "https://auth.example.com/v3", :token => "Token")
+    @swift_client = SwiftClient.new(storage_url: 'https://example.com/v1/AUTH_account', auth_url: 'https://auth.example.com/v3', token: 'Token')
 
-    assert_equal "Token", @swift_client.auth_token
-    assert_equal "https://example.com/v1/AUTH_account", @swift_client.storage_url
+    assert_equal 'Token', @swift_client.auth_token
+    assert_equal 'https://example.com/v1/AUTH_account', @swift_client.storage_url
   end
 
   def test_v3_authentication_username_domain_deprecation
     assert_raises SwiftClient::AuthenticationError do
-      SwiftClient.new :auth_url => "https://auth.example.com/v3", :username => "username", :domain => "example.com", :password => "secret"
+      SwiftClient.new auth_url: 'https://auth.example.com/v3', username: 'username', domain: 'example.com', password: 'secret'
     end
   end
 
   def test_v2_authentication_with_password
-    stub_request(:post, "https://auth.example.com/v2.0/tokens").with(:body => JSON.dump("auth" => { "tenantName" => "Tenant", "passwordCredentials" => { "username" => "Username", :password => "Password"  }})).to_return(:status => 200, :body => JSON.dump("access" => { "token" => { "id" => "Token" }}), :headers => { "Content-Type" => "application/json" })
+    stub_request(:post, 'https://auth.example.com/v2.0/tokens').with(body: JSON.dump('auth' => { 'tenantName' => 'Tenant', 'passwordCredentials' => { 'username' => 'Username', :password => 'Password' } })).to_return(status: 200, body: JSON.dump('access' => { 'token' => { 'id' => 'Token' } }), headers: { 'Content-Type' => 'application/json' })
 
-    @swift_client = SwiftClient.new(:storage_url => "https://example.com/v1/AUTH_account", :auth_url => "https://auth.example.com/v2.0", :tenant_name => "Tenant", :username => "Username", :password => "Password")
+    @swift_client = SwiftClient.new(storage_url: 'https://example.com/v1/AUTH_account', auth_url: 'https://auth.example.com/v2.0', tenant_name: 'Tenant', username: 'Username', password: 'Password')
 
-    assert_equal "Token", @swift_client.auth_token
-    assert_equal "https://example.com/v1/AUTH_account", @swift_client.storage_url
+    assert_equal 'Token', @swift_client.auth_token
+    assert_equal 'https://example.com/v1/AUTH_account', @swift_client.storage_url
   end
 
   def test_v2_authentication_with_key
-    stub_request(:post, "https://auth.example.com/v2.0/tokens").with(:body => JSON.dump("auth" => { "tenantName" => "Tenant", "apiAccessKeyCredentials" => { "accessKey" => "AccessKey", :secretKey => "SecretKey"  }})).to_return(:status => 200, :body => JSON.dump("access" => { "token" => { "id" => "Token" }}), :headers => { "Content-Type" => "application/json" })
+    stub_request(:post, 'https://auth.example.com/v2.0/tokens').with(body: JSON.dump('auth' => { 'tenantName' => 'Tenant', 'apiAccessKeyCredentials' => { 'accessKey' => 'AccessKey', :secretKey => 'SecretKey' } })).to_return(status: 200, body: JSON.dump('access' => { 'token' => { 'id' => 'Token' } }), headers: { 'Content-Type' => 'application/json' })
 
-    @swift_client = SwiftClient.new(:storage_url => "https://example.com/v1/AUTH_account", :auth_url => "https://auth.example.com/v2.0", :tenant_name => "Tenant", :access_key => "AccessKey", :secret_key => "SecretKey")
+    @swift_client = SwiftClient.new(storage_url: 'https://example.com/v1/AUTH_account', auth_url: 'https://auth.example.com/v2.0', tenant_name: 'Tenant', access_key: 'AccessKey', secret_key: 'SecretKey')
 
-    assert_equal "Token", @swift_client.auth_token
-    assert_equal "https://example.com/v1/AUTH_account", @swift_client.storage_url
+    assert_equal 'Token', @swift_client.auth_token
+    assert_equal 'https://example.com/v1/AUTH_account', @swift_client.storage_url
   end
 
   def test_storage_url
-    stub_request(:get, "https://example.com/auth/v1.0").with(:headers => { "X-Auth-Key" => "secret", "X-Auth-User" => "account:username" }).to_return(:status => 200, :body => "", :headers => { "X-Auth-Token" => "Token", "X-Storage-Url" => "https://example.com/v1/AUTH_account" })
+    stub_request(:get, 'https://example.com/auth/v1.0').with(headers: { 'X-Auth-Key' => 'secret', 'X-Auth-User' => 'account:username' }).to_return(status: 200, body: '', headers: { 'X-Auth-Token' => 'Token', 'X-Storage-Url' => 'https://example.com/v1/AUTH_account' })
 
-    @swift_client = SwiftClient.new(:auth_url => "https://example.com/auth/v1.0", :username => "account:username", :api_key => "secret", :storage_url => "https://storage-url.com/path")
+    @swift_client = SwiftClient.new(auth_url: 'https://example.com/auth/v1.0', username: 'account:username', api_key: 'secret', storage_url: 'https://storage-url.com/path')
 
-    assert_equal "Token", @swift_client.auth_token
-    assert_equal "https://storage-url.com/path", @swift_client.storage_url
+    assert_equal 'Token', @swift_client.auth_token
+    assert_equal 'https://storage-url.com/path', @swift_client.storage_url
   end
 
   def test_head_account
-    stub_request(:head, "https://example.com/v1/AUTH_account/").with(:headers => { "Accept" => "application/json", "X-Auth-Token" => "Token" }).to_return(:status => 204, :body => "", :headers => { "Content-Type" => "application/json" })
+    stub_request(:head, 'https://example.com/v1/AUTH_account/').with(headers: { 'Accept' => 'application/json', 'X-Auth-Token' => 'Token' }).to_return(status: 204, body: '', headers: { 'Content-Type' => 'application/json' })
 
     assert 204, @swift_client.head_account.code
   end
 
   def test_post_account
-    stub_request(:post, "https://example.com/v1/AUTH_account/").with(:headers => { "Accept" => "application/json", "X-Auth-Token" => "Token", "X-Account-Meta-Test" => "Test" }).to_return(:status => 204, :body => "", :headers => { "Content-Type" => "application/json" })
+    stub_request(:post, 'https://example.com/v1/AUTH_account/').with(headers: { 'Accept' => 'application/json', 'X-Auth-Token' => 'Token', 'X-Account-Meta-Test' => 'Test' }).to_return(status: 204, body: '', headers: { 'Content-Type' => 'application/json' })
 
-    assert_equal 204, @swift_client.post_account("X-Account-Meta-Test" => "Test").code
+    assert_equal 204, @swift_client.post_account('X-Account-Meta-Test' => 'Test').code
   end
 
   def test_head_containers
-    stub_request(:head, "https://example.com/v1/AUTH_account/").with(:headers => { "Accept" => "application/json", "X-Auth-Token" => "Token" }).to_return(:status => 204, :body => "", :headers => { "Content-Type" => "application/json" })
+    stub_request(:head, 'https://example.com/v1/AUTH_account/').with(headers: { 'Accept' => 'application/json', 'X-Auth-Token' => 'Token' }).to_return(status: 204, body: '', headers: { 'Content-Type' => 'application/json' })
 
     assert 204, @swift_client.head_containers.code
   end
 
   def test_get_containers
     containers = [
-      { "count" => 1, "bytes" => 1, "name" => "container-1" },
-      { "count" => 1, "bytes" => 1, "name" => "container-2" }
+      { 'count' => 1, 'bytes' => 1, 'name' => 'container-1' },
+      { 'count' => 1, 'bytes' => 1, 'name' => 'container-2' }
     ]
 
-    stub_request(:get, "https://example.com/v1/AUTH_account/").with(:headers => { "Accept" => "application/json", "X-Auth-Token" => "Token" }).to_return(:status => 200, :body => JSON.dump(containers), :headers => { "Content-Type" => "application/json" })
+    stub_request(:get, 'https://example.com/v1/AUTH_account/').with(headers: { 'Accept' => 'application/json', 'X-Auth-Token' => 'Token' }).to_return(status: 200, body: JSON.dump(containers), headers: { 'Content-Type' => 'application/json' })
 
     assert_equal containers, @swift_client.get_containers.parsed_response
   end
 
   def test_bulk_delete
     objects = [
-      "container1/object1",
-      "container1/object2",
-      "container2/object1"
+      'container1/object1',
+      'container1/object2',
+      'container2/object1'
     ]
 
-    stub_request(:delete, "https://example.com/v1/AUTH_account/?bulk-delete").with(:body => objects.join("\n"), :headers => { "Content-Type" => "text/plain", "X-Auth-Token" => "Token" }).to_return(:status => 200,:body => "", :headers => { "Content-Type" => "application/json" })
+    stub_request(:delete, 'https://example.com/v1/AUTH_account/?bulk-delete').with(body: objects.join("\n"), headers: { 'Content-Type' => 'text/plain', 'X-Auth-Token' => 'Token' }).to_return(status: 200, body: '', headers: { 'Content-Type' => 'application/json' })
 
     assert @swift_client.bulk_delete(objects)
   end
 
   def test_paginate_containers
     containers = [
-      { "count" => 1, "bytes" => 1, "name" => "container-1" },
-      { "count" => 1, "bytes" => 1, "name" => "container-2" },
-      { "count" => 1, "bytes" => 1, "name" => "container-3" }
+      { 'count' => 1, 'bytes' => 1, 'name' => 'container-1' },
+      { 'count' => 1, 'bytes' => 1, 'name' => 'container-2' },
+      { 'count' => 1, 'bytes' => 1, 'name' => 'container-3' }
     ]
 
-    stub_request(:get, "https://example.com/v1/AUTH_account/?limit=2").with(:headers => { "Accept" => "application/json", "X-Auth-Token" => "Token" }).to_return(:status => 200, :body => JSON.dump(containers[0 .. 1]), :headers => { "Content-Type" => "application/json" })
-    stub_request(:get, "https://example.com/v1/AUTH_account/?limit=2&marker=container-2").with(:headers => { "Accept" => "application/json", "X-Auth-Token" => "Token" }).to_return(:status => 200, :body => JSON.dump(containers[2 .. 3]), :headers => { "Content-Type" => "application/json" })
-    stub_request(:get, "https://example.com/v1/AUTH_account/?limit=2&marker=container-3").with(:headers => { "Accept" => "application/json", "X-Auth-Token" => "Token" }).to_return(:status => 200, :body => JSON.dump([]), :headers => { "Content-Type" => "application/json" })
+    stub_request(:get, 'https://example.com/v1/AUTH_account/?limit=2').with(headers: { 'Accept' => 'application/json', 'X-Auth-Token' => 'Token' }).to_return(status: 200, body: JSON.dump(containers[0..1]), headers: { 'Content-Type' => 'application/json' })
+    stub_request(:get, 'https://example.com/v1/AUTH_account/?limit=2&marker=container-2').with(headers: { 'Accept' => 'application/json', 'X-Auth-Token' => 'Token' }).to_return(status: 200, body: JSON.dump(containers[2..3]), headers: { 'Content-Type' => 'application/json' })
+    stub_request(:get, 'https://example.com/v1/AUTH_account/?limit=2&marker=container-3').with(headers: { 'Accept' => 'application/json', 'X-Auth-Token' => 'Token' }).to_return(status: 200, body: JSON.dump([]), headers: { 'Content-Type' => 'application/json' })
 
-    assert_equal containers, @swift_client.paginate_containers(:limit => 2).collect(&:parsed_response).flatten
+    assert_equal containers, @swift_client.paginate_containers(limit: 2).collect(&:parsed_response).flatten
   end
 
   def test_get_container
     objects = [
-      { "hash" => "Hash", "last_modified" => "Last modified", "bytes" => 1, "name" => "object-2", "content_type" => "Content type" },
-      { "hash" => "Hash", "last_modified" => "Last modified", "bytes" => 1, "name" => "object-3", "content_type" => "Content type" }
+      { 'hash' => 'Hash', 'last_modified' => 'Last modified', 'bytes' => 1, 'name' => 'object-2', 'content_type' => 'Content type' },
+      { 'hash' => 'Hash', 'last_modified' => 'Last modified', 'bytes' => 1, 'name' => 'object-3', 'content_type' => 'Content type' }
     ]
 
-    stub_request(:get, "https://example.com/v1/AUTH_account/container-1?limit=2&marker=object-2").with(:headers => { "Accept" => "application/json", "X-Auth-Token" => "Token" }).to_return(:status => 200, :body => JSON.dump(objects), :headers => { "Content-Type" => "application/json" })
+    stub_request(:get, 'https://example.com/v1/AUTH_account/container-1?limit=2&marker=object-2').with(headers: { 'Accept' => 'application/json', 'X-Auth-Token' => 'Token' }).to_return(status: 200, body: JSON.dump(objects), headers: { 'Content-Type' => 'application/json' })
 
-    assert_equal objects, @swift_client.get_container("container-1", :limit => 2, :marker => "object-2").parsed_response
+    assert_equal objects, @swift_client.get_container('container-1', limit: 2, marker: 'object-2').parsed_response
   end
 
   def test_paginate_container
     objects = [
-      { "hash" => "Hash", "last_modified" => "Last modified", "bytes" => 1, "name" => "object-1", "content_type" => "Content type" },
-      { "hash" => "Hash", "last_modified" => "Last modified", "bytes" => 1, "name" => "object-2", "content_type" => "Content type" },
-      { "hash" => "Hash", "last_modified" => "Last modified", "bytes" => 1, "name" => "object-3", "content_type" => "Content type" },
+      { 'hash' => 'Hash', 'last_modified' => 'Last modified', 'bytes' => 1, 'name' => 'object-1', 'content_type' => 'Content type' },
+      { 'hash' => 'Hash', 'last_modified' => 'Last modified', 'bytes' => 1, 'name' => 'object-2', 'content_type' => 'Content type' },
+      { 'hash' => 'Hash', 'last_modified' => 'Last modified', 'bytes' => 1, 'name' => 'object-3', 'content_type' => 'Content type' }
     ]
 
-    stub_request(:get, "https://example.com/v1/AUTH_account/container-1?limit=2").with(:headers => { "Accept" => "application/json", "X-Auth-Token" => "Token" }).to_return(:status => 200, :body => JSON.dump(objects[0 .. 1]), :headers => { "Content-Type" => "application/json" })
-    stub_request(:get, "https://example.com/v1/AUTH_account/container-1?limit=2&marker=object-2").with(:headers => { "Accept" => "application/json", "X-Auth-Token" => "Token" }).to_return(:status => 200, :body => JSON.dump(objects[2 .. 3]), :headers => { "Content-Type" => "application/json" })
-    stub_request(:get, "https://example.com/v1/AUTH_account/container-1?limit=2&marker=object-3").with(:headers => { "Accept" => "application/json", "X-Auth-Token" => "Token" }).to_return(:status => 200, :body => JSON.dump([]), :headers => { "Content-Type" => "application/json" })
+    stub_request(:get, 'https://example.com/v1/AUTH_account/container-1?limit=2').with(headers: { 'Accept' => 'application/json', 'X-Auth-Token' => 'Token' }).to_return(status: 200, body: JSON.dump(objects[0..1]), headers: { 'Content-Type' => 'application/json' })
+    stub_request(:get, 'https://example.com/v1/AUTH_account/container-1?limit=2&marker=object-2').with(headers: { 'Accept' => 'application/json', 'X-Auth-Token' => 'Token' }).to_return(status: 200, body: JSON.dump(objects[2..3]), headers: { 'Content-Type' => 'application/json' })
+    stub_request(:get, 'https://example.com/v1/AUTH_account/container-1?limit=2&marker=object-3').with(headers: { 'Accept' => 'application/json', 'X-Auth-Token' => 'Token' }).to_return(status: 200, body: JSON.dump([]), headers: { 'Content-Type' => 'application/json' })
 
-    assert_equal objects, @swift_client.paginate_container("container-1", :limit => 2).collect(&:parsed_response).flatten
+    assert_equal objects, @swift_client.paginate_container('container-1', limit: 2).collect(&:parsed_response).flatten
   end
 
   def test_head_container
-    stub_request(:head, "https://example.com/v1/AUTH_account/container-1").with(:headers => { "Accept" => "application/json", "X-Auth-Token" => "Token" }).to_return(:status => 204, :body => "", :headers => { "Content-Type" => "application/json" })
+    stub_request(:head, 'https://example.com/v1/AUTH_account/container-1').with(headers: { 'Accept' => 'application/json', 'X-Auth-Token' => 'Token' }).to_return(status: 204, body: '', headers: { 'Content-Type' => 'application/json' })
 
-    assert 204, @swift_client.head_container("container-1").code
+    assert 204, @swift_client.head_container('container-1').code
   end
 
   def test_put_container
-    stub_request(:put, "https://example.com/v1/AUTH_account/container").with(:headers => { "Accept" => "application/json", "X-Auth-Token" => "Token", "X-Container-Read" => ".r:*" }).to_return(:status => 201, :body => "", :headers => {})
+    stub_request(:put, 'https://example.com/v1/AUTH_account/container').with(headers: { 'Accept' => 'application/json', 'X-Auth-Token' => 'Token', 'X-Container-Read' => '.r:*' }).to_return(status: 201, body: '', headers: {})
 
-    assert_equal 201, @swift_client.put_container("container", "X-Container-Read" => ".r:*").code
+    assert_equal 201, @swift_client.put_container('container', 'X-Container-Read' => '.r:*').code
   end
 
   def test_post_container
-    stub_request(:post, "https://example.com/v1/AUTH_account/container").with(:headers => { "Accept" => "application/json", "X-Auth-Token" => "Token", "X-Container-Read" => ".r:*" }).to_return(:status => 204, :body => "", :headers => {})
+    stub_request(:post, 'https://example.com/v1/AUTH_account/container').with(headers: { 'Accept' => 'application/json', 'X-Auth-Token' => 'Token', 'X-Container-Read' => '.r:*' }).to_return(status: 204, body: '', headers: {})
 
-    assert_equal 204, @swift_client.post_container("container", "X-Container-Read" => ".r:*").code
+    assert_equal 204, @swift_client.post_container('container', 'X-Container-Read' => '.r:*').code
   end
 
   def test_delete_container
-    stub_request(:delete, "https://example.com/v1/AUTH_account/container").with(:headers => { "Accept" => "application/json", "X-Auth-Token" => "Token" }).to_return(:status => 204, :body => "", :headers => {})
+    stub_request(:delete, 'https://example.com/v1/AUTH_account/container').with(headers: { 'Accept' => 'application/json', 'X-Auth-Token' => 'Token' }).to_return(status: 204, body: '', headers: {})
 
-    assert_equal 204, @swift_client.delete_container("container").code
+    assert_equal 204, @swift_client.delete_container('container').code
   end
 
   def test_put_object
-    stub_request(:put, "https://example.com/v1/AUTH_account/container/object").with(:body => "data", :headers => { "Transfer-Encoding" => "chunked", "Content-Type" => "application/octet-stream", "Accept" => "application/json", "X-Auth-Token" => "Token", "X-Object-Meta-Test" => "Test" }).to_return(:status => 201, :body => "", :headers => {})
+    stub_request(:put, 'https://example.com/v1/AUTH_account/container/object').with(body: 'data', headers: { 'Transfer-Encoding' => 'chunked', 'Content-Type' => 'application/octet-stream', 'Accept' => 'application/json', 'X-Auth-Token' => 'Token', 'X-Object-Meta-Test' => 'Test' }).to_return(status: 201, body: '', headers: {})
 
-    assert_equal 201, @swift_client.put_object("object", "data", "container", "X-Object-Meta-Test" => "Test").code
+    assert_equal 201, @swift_client.put_object('object', 'data', 'container', 'X-Object-Meta-Test' => 'Test').code
   end
 
   def test_put_object_with_renewed_authorization
-    stub_request(:put, "https://example.com/v1/AUTH_account/container/object").with(:body => "data", :headers => { "Transfer-Encoding" => "chunked", "Content-Type" => "application/octet-stream", "Accept" => "application/json", "X-Auth-Token" => "Token" }).to_return({ :status => 401, :body => "", :headers => {}}, { :status => 201, :body => "", :headers => {}})
+    stub_request(:put, 'https://example.com/v1/AUTH_account/container/object').with(body: 'data', headers: { 'Transfer-Encoding' => 'chunked', 'Content-Type' => 'application/octet-stream', 'Accept' => 'application/json', 'X-Auth-Token' => 'Token' }).to_return({ status: 401, body: '', headers: {} }, status: 201, body: '', headers: {})
 
-    assert_equal 201, @swift_client.put_object("object", "data", "container").code
+    assert_equal 201, @swift_client.put_object('object', 'data', 'container').code
   end
 
   def test_put_object_without_mime_type
-    stub_request(:put, "https://example.com/v1/AUTH_account/container/object.jpg").with(:body => "data", :headers => { "Transfer-Encoding" => "chunked", "Accept" => "application/json", "Content-Type" => "image/jpeg", "X-Auth-Token" => "Token", "X-Object-Meta-Test" => "Test" }).to_return(:status => 201, :body => "", :headers => {})
+    stub_request(:put, 'https://example.com/v1/AUTH_account/container/object.jpg').with(body: 'data', headers: { 'Transfer-Encoding' => 'chunked', 'Accept' => 'application/json', 'Content-Type' => 'image/jpeg', 'X-Auth-Token' => 'Token', 'X-Object-Meta-Test' => 'Test' }).to_return(status: 201, body: '', headers: {})
 
-    assert_equal 201, @swift_client.put_object("object.jpg", "data", "container", "X-Object-Meta-Test" => "Test").code
+    assert_equal 201, @swift_client.put_object('object.jpg', 'data', 'container', 'X-Object-Meta-Test' => 'Test').code
   end
 
   def test_put_object_with_mime_type
-    stub_request(:put, "https://example.com/v1/AUTH_account/container/object.jpg").with(:body => "data", :headers => { "Transfer-Encoding" => "chunked", "Accept" => "application/json", "Content-Type" => "content/type", "X-Auth-Token" => "Token", "X-Object-Meta-Test" => "Test" }).to_return(:status => 201, :body => "", :headers => {})
+    stub_request(:put, 'https://example.com/v1/AUTH_account/container/object.jpg').with(body: 'data', headers: { 'Transfer-Encoding' => 'chunked', 'Accept' => 'application/json', 'Content-Type' => 'content/type', 'X-Auth-Token' => 'Token', 'X-Object-Meta-Test' => 'Test' }).to_return(status: 201, body: '', headers: {})
 
-    assert_equal 201, @swift_client.put_object("object.jpg", "data", "container", "X-Object-Meta-Test" => "Test", "Content-Type" => "content/type").code
+    assert_equal 201, @swift_client.put_object('object.jpg', 'data', 'container', 'X-Object-Meta-Test' => 'Test', 'Content-Type' => 'content/type').code
   end
 
   def test_put_object_with_io
-    stub_request(:put, "https://example.com/v1/AUTH_account/container/object").with(:body => "data", :headers => { "Transfer-Encoding" => "chunked", "Accept" => "application/json", "X-Auth-Token" => "Token", "X-Object-Meta-Test" => "Test" }).to_return(:status => 201, :body => "", :headers => {})
+    stub_request(:put, 'https://example.com/v1/AUTH_account/container/object').with(body: 'data', headers: { 'Transfer-Encoding' => 'chunked', 'Accept' => 'application/json', 'X-Auth-Token' => 'Token', 'X-Object-Meta-Test' => 'Test' }).to_return(status: 201, body: '', headers: {})
 
-    assert_equal 201, @swift_client.put_object("object", StringIO.new("data"), "container", "X-Object-Meta-Test" => "Test").code
+    assert_equal 201, @swift_client.put_object('object', StringIO.new('data'), 'container', 'X-Object-Meta-Test' => 'Test').code
   end
 
   def test_post_object
-    stub_request(:post, "https://example.com/v1/AUTH_account/container/object").with(:headers => { "Accept" => "application/json", "X-Auth-Token" => "Token", "X-Object-Meta-Test" => "Test" }).to_return(:status => 201, :body => "", :headers => {})
+    stub_request(:post, 'https://example.com/v1/AUTH_account/container/object').with(headers: { 'Accept' => 'application/json', 'X-Auth-Token' => 'Token', 'X-Object-Meta-Test' => 'Test' }).to_return(status: 201, body: '', headers: {})
 
-    assert_equal 201, @swift_client.post_object("object", "container", "X-Object-Meta-Test" => "Test").code
+    assert_equal 201, @swift_client.post_object('object', 'container', 'X-Object-Meta-Test' => 'Test').code
   end
 
   def test_get_object
-    stub_request(:get, "https://example.com/v1/AUTH_account/container/object").with(:headers => { "Accept" => "application/json", "X-Auth-Token" => "Token" }).to_return(:status => 200, :body => "Body", :headers => {})
+    stub_request(:get, 'https://example.com/v1/AUTH_account/container/object').with(headers: { 'Accept' => 'application/json', 'X-Auth-Token' => 'Token' }).to_return(status: 200, body: 'Body', headers: {})
     block_res = 0
 
-    large_body = "Body" * 16384
-    stub_request(:get, "https://example.com/v1/AUTH_account/container/large_object").with(:headers => { "Accept" => "application/json", "X-Auth-Token" => "Token" }).to_return(:status => 200, :body => large_body, :headers => {})
+    large_body = 'Body' * 16_384
+    stub_request(:get, 'https://example.com/v1/AUTH_account/container/large_object').with(headers: { 'Accept' => 'application/json', 'X-Auth-Token' => 'Token' }).to_return(status: 200, body: large_body, headers: {})
 
-    assert_equal "Body", @swift_client.get_object("object", "container").body
+    assert_equal 'Body', @swift_client.get_object('object', 'container').body
 
-    @swift_client.get_object("large_object", "container") do |chunk|
+    @swift_client.get_object('large_object', 'container') do |chunk|
       block_res += chunk.length
     end
 
@@ -301,61 +300,61 @@ class SwiftClientTest < MiniTest::Test
   end
 
   def test_head_object
-    stub_request(:head, "https://example.com/v1/AUTH_account/container/object").with(:headers => { "Accept" => "application/json", "X-Auth-Token" => "Token" }).to_return(:status => 200, :body => "", :headers => {})
+    stub_request(:head, 'https://example.com/v1/AUTH_account/container/object').with(headers: { 'Accept' => 'application/json', 'X-Auth-Token' => 'Token' }).to_return(status: 200, body: '', headers: {})
 
-    assert_equal 200, @swift_client.head_object("object", "container").code
+    assert_equal 200, @swift_client.head_object('object', 'container').code
   end
 
   def test_delete_object
-    stub_request(:delete, "https://example.com/v1/AUTH_account/container/object").with(:headers => { "Accept" => "application/json", "X-Auth-Token" => "Token" }).to_return(:status => 204, :body => "", :headers => {})
+    stub_request(:delete, 'https://example.com/v1/AUTH_account/container/object').with(headers: { 'Accept' => 'application/json', 'X-Auth-Token' => 'Token' }).to_return(status: 204, body: '', headers: {})
 
-    assert_equal 204, @swift_client.delete_object("object", "container").code
+    assert_equal 204, @swift_client.delete_object('object', 'container').code
   end
 
   def test_get_objects
     objects = [
-      { "hash" => "Hash", "last_modified" => "Last modified", "bytes" => 1, "name" => "object-2", "content_type" => "Content type" },
-      { "hash" => "Hash", "last_modified" => "Last modified", "bytes" => 1, "name" => "object-3", "content_type" => "Content type" }
+      { 'hash' => 'Hash', 'last_modified' => 'Last modified', 'bytes' => 1, 'name' => 'object-2', 'content_type' => 'Content type' },
+      { 'hash' => 'Hash', 'last_modified' => 'Last modified', 'bytes' => 1, 'name' => 'object-3', 'content_type' => 'Content type' }
     ]
 
-    stub_request(:get, "https://example.com/v1/AUTH_account/container-1?limit=2&marker=object-2").with(:headers => { "Accept" => "application/json", "X-Auth-Token" => "Token" }).to_return(:status => 200, :body => JSON.dump(objects), :headers => { "Content-Type" => "application/json" })
+    stub_request(:get, 'https://example.com/v1/AUTH_account/container-1?limit=2&marker=object-2').with(headers: { 'Accept' => 'application/json', 'X-Auth-Token' => 'Token' }).to_return(status: 200, body: JSON.dump(objects), headers: { 'Content-Type' => 'application/json' })
 
-    assert_equal objects, @swift_client.get_objects("container-1", :limit => 2, :marker => "object-2").parsed_response
+    assert_equal objects, @swift_client.get_objects('container-1', limit: 2, marker: 'object-2').parsed_response
   end
 
   def test_paginate_objects
     objects = [
-      { "hash" => "Hash", "last_modified" => "Last modified", "bytes" => 1, "name" => "object-1", "content_type" => "Content type" },
-      { "hash" => "Hash", "last_modified" => "Last modified", "bytes" => 1, "name" => "object-2", "content_type" => "Content type" },
-      { "hash" => "Hash", "last_modified" => "Last modified", "bytes" => 1, "name" => "object-3", "content_type" => "Content type" }
+      { 'hash' => 'Hash', 'last_modified' => 'Last modified', 'bytes' => 1, 'name' => 'object-1', 'content_type' => 'Content type' },
+      { 'hash' => 'Hash', 'last_modified' => 'Last modified', 'bytes' => 1, 'name' => 'object-2', 'content_type' => 'Content type' },
+      { 'hash' => 'Hash', 'last_modified' => 'Last modified', 'bytes' => 1, 'name' => 'object-3', 'content_type' => 'Content type' }
     ]
 
-    stub_request(:get, "https://example.com/v1/AUTH_account/container-1?limit=2").with(:headers => { "Accept" => "application/json", "X-Auth-Token" => "Token" }).to_return(:status => 200, :body => JSON.dump(objects[0 .. 1]), :headers => { "Content-Type" => "application/json" })
-    stub_request(:get, "https://example.com/v1/AUTH_account/container-1?limit=2&marker=object-2").with(:headers => { "Accept" => "application/json", "X-Auth-Token" => "Token" }).to_return(:status => 200, :body => JSON.dump(objects[2 .. 3]), :headers => { "Content-Type" => "application/json" })
-    stub_request(:get, "https://example.com/v1/AUTH_account/container-1?limit=2&marker=object-3").with(:headers => { "Accept" => "application/json", "X-Auth-Token" => "Token" }).to_return(:status => 200, :body => JSON.dump([]), :headers => { "Content-Type" => "application/json" })
+    stub_request(:get, 'https://example.com/v1/AUTH_account/container-1?limit=2').with(headers: { 'Accept' => 'application/json', 'X-Auth-Token' => 'Token' }).to_return(status: 200, body: JSON.dump(objects[0..1]), headers: { 'Content-Type' => 'application/json' })
+    stub_request(:get, 'https://example.com/v1/AUTH_account/container-1?limit=2&marker=object-2').with(headers: { 'Accept' => 'application/json', 'X-Auth-Token' => 'Token' }).to_return(status: 200, body: JSON.dump(objects[2..3]), headers: { 'Content-Type' => 'application/json' })
+    stub_request(:get, 'https://example.com/v1/AUTH_account/container-1?limit=2&marker=object-3').with(headers: { 'Accept' => 'application/json', 'X-Auth-Token' => 'Token' }).to_return(status: 200, body: JSON.dump([]), headers: { 'Content-Type' => 'application/json' })
 
-    assert_equal objects, @swift_client.paginate_objects("container-1", :limit => 2).collect(&:parsed_response).flatten
+    assert_equal objects, @swift_client.paginate_objects('container-1', limit: 2).collect(&:parsed_response).flatten
   end
 
   def test_not_found
-    stub_request(:get, "https://example.com/v1/AUTH_account/container/object").with(:headers => { "Accept" => "application/json", "X-Auth-Token" => "Token" }).to_return(:status => [404, "Not Found"], :body => "", :headers => { "Content-Type" => "application/json" })
+    stub_request(:get, 'https://example.com/v1/AUTH_account/container/object').with(headers: { 'Accept' => 'application/json', 'X-Auth-Token' => 'Token' }).to_return(status: [404, 'Not Found'], body: '', headers: { 'Content-Type' => 'application/json' })
 
     begin
-      @swift_client.get_object("object", "container")
+      @swift_client.get_object('object', 'container')
     rescue SwiftClient::ResponseError => e
       assert_equal 404, e.code
-      assert_equal "Not Found", e.message
+      assert_equal 'Not Found', e.message
     end
   end
 
   def test_public_url
-    assert_equal "https://example.com/v1/AUTH_account/container/object", @swift_client.public_url("object", "container")
+    assert_equal 'https://example.com/v1/AUTH_account/container/object', @swift_client.public_url('object', 'container')
   end
 
   def test_temp_url
     Time.expects(:now).at_least_once.returns(1_000_000)
 
-    assert @swift_client.temp_url("object", "container") =~ %r{https://example.com/v1/AUTH_account/container/object\?temp_url_sig=[a-f0-9]{40}&temp_url_expires=1003600}
-    assert @swift_client.temp_url("object", "container", :expires_in => 86400) =~ %r{https://example.com/v1/AUTH_account/container/object\?temp_url_sig=[a-f0-9]{40}&temp_url_expires=1086400}
+    assert @swift_client.temp_url('object', 'container') =~ %r{https://example.com/v1/AUTH_account/container/object\?temp_url_sig=[a-f0-9]{40}&temp_url_expires=1003600}
+    assert @swift_client.temp_url('object', 'container', expires_in: 86_400) =~ %r{https://example.com/v1/AUTH_account/container/object\?temp_url_sig=[a-f0-9]{40}&temp_url_expires=1086400}
   end
 end


### PR DESCRIPTION
Add the possibility to update headers on existing objects. One use case i'm trying to deal with is to add an expiration date to existing objects. This is done by adding a header to the existing objects:

https://docs.openstack.org/ocata/user-guide/cli-swift-set-object-expiration.html

Would be nice to get this PR so I can continue using this client.