### PR TITLE
Allow `:json => false` to disable Accept header

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,8 @@ SwiftClient offers the following requests:
 * `bulk_delete(entries, options = {}) # => entries`
 * `post_head(object_name, container_name, _headers = {}, options = {}) # => HTTParty::Response`
 
+By default, the client instructs the Swift server to return JSON via an HTTP Accept header; to disable this pass `:json => false` in `options`. The rest of the `options` are passed directly to the internal [HTTParty](https://rubygems.org/gems/httparty) client.
+
 ### Getting large objects
 The `get_object` method with out a block is suitable for small objects that easily fit in memory. For larger objects, specify a block to process chunked data as it comes in.
 

--- a/lib/swift_client.rb
+++ b/lib/swift_client.rb
@@ -195,7 +195,7 @@ class SwiftClient
   def request(method, path, opts = {}, &block)
     headers = (opts[:headers] || {}).dup
     headers["X-Auth-Token"] = auth_token
-    headers["Accept"] = "application/json"
+    headers["Accept"] ||= "application/json" unless opts.delete(:json) == false
 
     stream_pos = opts[:body_stream].pos if opts[:body_stream]
 

--- a/test/swift_client_test.rb
+++ b/test/swift_client_test.rb
@@ -341,6 +341,14 @@ class SwiftClientTest < MiniTest::Test
     assert_equal objects, @swift_client.get_objects("container-1", :limit => 2, :marker => "object-2").parsed_response
   end
 
+  def test_get_objects_no_json
+    response = "object-2\nobject-3\n"
+
+    stub_request(:get, "https://example.com/v1/AUTH_account/container-1?limit=2&marker=object-2").with(:headers => { "X-Auth-Token" => "Token" }).to_return(:status => 200, :body => response, :headers => { "Content-Type" => "text/html" })
+
+    assert_equal response, @swift_client.get_objects("container-1", { :limit => 2, :marker => "object-2" }, :json => false).body
+  end
+
   def test_paginate_objects
     objects = [
       { "hash" => "Hash", "last_modified" => "Last modified", "bytes" => 1, "name" => "object-1", "content_type" => "Content type" },


### PR DESCRIPTION
For those times you don't want the JSON traffic and parsing.

Also allow overriding the Accept header.

Fixes https://github.com/mrkamel/swift_client/issues/11