### PR TITLE
Remove '< 3.0' version constraint on mime-types

### DIFF
--- a/swift_client.gemspec
+++ b/swift_client.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "httparty"
-  spec.add_dependency "mime-types", "< 3.0"
+  spec.add_dependency "mime-types"
 
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"


### PR DESCRIPTION
mime-types 3+ dropped support for ruby 1.9. The '< 3.0' requirement prevents httparty over 0.16.2; it's currently 0.18.1

I see this project's travis.yml dropped ruby 1.9 support a while back so hope this is OK.

Tests pass.

>  Resolving dependencies...
  Using rake 13.0.1
  Using public_suffix 4.0.5
  Using addressable 2.7.0
  Using bundler 2.1.4
  Using safe_yaml 1.0.5
  Using crack 0.4.3
  Using hashdiff 1.0.1
  Using mime-types-data 3.2020.0512
  Using mime-types 3.3.1 (was 2.99.3)
  Using multi_xml 0.6.0
  Fetching httparty 0.18.1 (was 0.16.2)
  Installing httparty 0.18.1 (was 0.16.2)
  Using minitest 5.14.1
  Using mocha 1.11.2
  Using swift_client 0.2.0 from source at `.`
  Using webmock 3.8.3
  Bundle updated!

Concrete example problem in the wild,

>   In Gemfile:
    swift_client was resolved to 0.2.0, which depends on
      httparty was resolved to 0.18.1, which depends on
        mime-types (~> 3.0)
>    swift_client was resolved to 0.2.0, which depends on
      mime-types (< 3.0)