### PR TITLE
Set query default to nil

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,10 +130,10 @@ SwiftClient offers the following requests:
 * `head_account(options = {}) # => HTTParty::Response`
 * `post_account(headers = {}, options = {}) # => HTTParty::Response`
 * `head_containers(options = {}) # => HTTParty::Response`
-* `get_containers(query = {}, options = {}) # => HTTParty::Response`
-* `paginate_containers(query = {}, options = {}) # => Enumerator`
-* `get_container(container_name, query = {}, options = {}) # => HTTParty::Response`
-* `paginate_container(container_name, query = {}, options = {}) # => Enumerator`
+* `get_containers(query = nil, options = {}) # => HTTParty::Response`
+* `paginate_containers(query = nil, options = {}) # => Enumerator`
+* `get_container(container_name, query = nil, options = {}) # => HTTParty::Response`
+* `paginate_container(container_name, query = nil, options = {}) # => Enumerator`
 * `head_container(container_name, options = {}) # => HTTParty::Response`
 * `put_container(container_name, headers = {}, options = {}) # => HTTParty::Response`
 * `post_container(container_name, headers = {}, options = {}) # => HTTParty::Response`
@@ -144,8 +144,8 @@ SwiftClient offers the following requests:
 * `get_object(object_name, container_name, options = {}) { |chunk| save chunk } # => HTTParty::Response`
 * `head_object(object_name, container_name, options = {}) # => HTTParty::Response`
 * `delete_object(object_name, container_name, options = {}) # => HTTParty::Response`
-* `get_objects(container_name, query = {}, options = {}) # => HTTParty::Response`
-* `paginate_objects(container_name, query = {}, options = {}) # => Enumerator`
+* `get_objects(container_name, query = nil, options = {}) # => HTTParty::Response`
+* `paginate_objects(container_name, query = nil, options = {}) # => Enumerator`
 * `public_url(object_name, container_name) # => HTTParty::Response`
 * `temp_url(object_name, container_name, options = {}) # => HTTParty::Response`
 * `bulk_delete(entries, options = {}) # => entries`
@@ -154,6 +154,7 @@ SwiftClient offers the following requests:
 By default, the client instructs the Swift server to return JSON via an HTTP Accept header; to disable this pass `:json => false` in `options`. The rest of the `options` are passed directly to the internal [HTTParty](https://rubygems.org/gems/httparty) client.
 
 ### Getting large objects
+
 The `get_object` method with out a block is suitable for small objects that easily fit in memory. For larger objects, specify a block to process chunked data as it comes in.
 
 ```ruby

--- a/lib/swift_client.rb
+++ b/lib/swift_client.rb
@@ -49,21 +49,21 @@ class SwiftClient
     request :head, "/", options
   end
 
-  def get_containers(query = {}, options = {})
+  def get_containers(query = nil, options = {})
     request :get, "/", options.merge(:query => query)
   end
 
-  def paginate_containers(query = {}, options = {}, &block)
+  def paginate_containers(query = nil, options = {}, &block)
     paginate(:get_containers, query, options, &block)
   end
 
-  def get_container(container_name, query = {}, options = {})
+  def get_container(container_name, query = nil, options = {})
     raise(EmptyNameError) if container_name.empty?
 
     request :get, "/#{container_name}", options.merge(:query => query)
   end
 
-  def paginate_container(container_name, query = {}, options = {}, &block)
+  def paginate_container(container_name, query = nil, options = {}, &block)
     paginate(:get_container, container_name, query, options, &block)
   end
 
@@ -141,13 +141,13 @@ class SwiftClient
     request :delete, "/#{container_name}/#{object_name}", options
   end
 
-  def get_objects(container_name, query = {}, options = {})
+  def get_objects(container_name, query = nil, options = {})
     raise(EmptyNameError) if container_name.empty?
 
     request :get, "/#{container_name}", options.merge(:query => query)
   end
 
-  def paginate_objects(container_name, query = {}, options = {}, &block)
+  def paginate_objects(container_name, query = nil, options = {}, &block)
     paginate(:get_objects, container_name, query, options, &block)
   end
 

--- a/lib/swift_client.rb
+++ b/lib/swift_client.rb
@@ -357,7 +357,7 @@ class SwiftClient
     marker = nil
 
     loop do
-      response = send(method, *args, marker ? query.merge(:marker => marker) : query, options)
+      response = send(method, *args, marker ? (query || {}).merge(:marker => marker) : query, options)
 
       return if response.parsed_response.empty?
 

--- a/test/swift_client_test.rb
+++ b/test/swift_client_test.rb
@@ -173,6 +173,17 @@ class SwiftClientTest < MiniTest::Test
     assert_equal containers, @swift_client.get_containers.parsed_response
   end
 
+  def test_get_containers_without_query
+    containers = [
+      { "count" => 1, "bytes" => 1, "name" => "container-1" },
+      { "count" => 1, "bytes" => 1, "name" => "container-2" }
+    ]
+
+    stub_request(:get, "https://example.com/v1/AUTH_account/").with(:headers => { "Accept" => "application/json", "X-Auth-Token" => "Token" }).to_return(:status => 200, :body => JSON.dump(containers), :headers => { "Content-Type" => "application/json" })
+
+    assert_equal containers, @swift_client.get_containers.parsed_response
+  end
+
   def test_bulk_delete
     objects = [
       "container1/object1",

--- a/test/swift_client_test.rb
+++ b/test/swift_client_test.rb
@@ -374,6 +374,19 @@ class SwiftClientTest < MiniTest::Test
     assert_equal objects, @swift_client.paginate_objects("container-1", :limit => 2).collect(&:parsed_response).flatten
   end
 
+  def test_paginate_objects_no_limit
+    objects = [
+      { "hash" => "Hash", "last_modified" => "Last modified", "bytes" => 1, "name" => "object-1", "content_type" => "Content type" },
+      { "hash" => "Hash", "last_modified" => "Last modified", "bytes" => 1, "name" => "object-2", "content_type" => "Content type" },
+      { "hash" => "Hash", "last_modified" => "Last modified", "bytes" => 1, "name" => "object-3", "content_type" => "Content type" }
+    ]
+
+    stub_request(:get, "https://example.com/v1/AUTH_account/container-1").with(:headers => { "Accept" => "application/json", "X-Auth-Token" => "Token" }).to_return(:status => 200, :body => JSON.dump(objects), :headers => { "Content-Type" => "application/json" })
+    stub_request(:get, "https://example.com/v1/AUTH_account/container-1?marker=object-3").with(:headers => { "Accept" => "application/json", "X-Auth-Token" => "Token" }).to_return(:status => 200, :body => JSON.dump([]), :headers => { "Content-Type" => "application/json" })
+
+    assert_equal objects, @swift_client.paginate_objects("container-1").collect(&:parsed_response).flatten
+  end
+
   def test_not_found
     stub_request(:get, "https://example.com/v1/AUTH_account/container/object").with(:headers => { "Accept" => "application/json", "X-Auth-Token" => "Token" }).to_return(:status => [404, "Not Found"], :body => "", :headers => { "Content-Type" => "application/json" })
 


### PR DESCRIPTION
The `{}` empty query default ultimately causes HTTParty to emit a trailing `?` on the URL which can cause a 503 on braindead Swift servers:

```
swift_client-test % curl -s -i -H "$auth" "https://server:8083/v1/AUTH_foo/container" | head -1
HTTP/1.1 200 OK
swift_client-test % curl -s -i -H "$auth" "https://server:8083/v1/AUTH_foo/container?" | head -1
HTTP/1.1 503 Internal Server Error
```

Unit tests pass.