### PR TITLE
Use `:format => "plain"` for newline-delimited output

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ SwiftClient offers the following requests:
 * `bulk_delete(entries, options = {}) # => entries`
 * `post_head(object_name, container_name, _headers = {}, options = {}) # => HTTParty::Response`
 
-By default, the client instructs the endpoint to return JSON via an HTTP Accept header; to specify another format pass, e.g., `:format => "plain"` in `query` ("xml" is also [supported in the Object Storage API](https://docs.openstack.org/api-ref/object-store/index.html?expanded=show-container-details-and-list-objects-detail#show-container-details-and-list-objects)).
+By default, the client instructs the endpoint to return JSON via an HTTP Accept header. To specify another format pass, e.g., `:format => "plain"` via the `query` parameter of the `get_*` and `paginate_*` methods. Other formats, like `"xml"` are supported as well. Checkout [Object Storage API](https://docs.openstack.org/api-ref/object-store/index.html?expanded=show-container-details-and-list-objects-detail#show-container-details-and-list-objects) for more details.
 
 All `options` are passed directly to the internal [HTTParty](https://rubygems.org/gems/httparty) client.
 

--- a/README.md
+++ b/README.md
@@ -151,7 +151,9 @@ SwiftClient offers the following requests:
 * `bulk_delete(entries, options = {}) # => entries`
 * `post_head(object_name, container_name, _headers = {}, options = {}) # => HTTParty::Response`
 
-By default, the client instructs the Swift server to return JSON via an HTTP Accept header; to disable this pass `:json => false` in `options`. The rest of the `options` are passed directly to the internal [HTTParty](https://rubygems.org/gems/httparty) client.
+By default, the client instructs the endpoint to return JSON via an HTTP Accept header; to specify another format pass, e.g., `:format => "plain"` in `query` ("xml" is also [supported in the Object Storage API](https://docs.openstack.org/api-ref/object-store/index.html?expanded=show-container-details-and-list-objects-detail#show-container-details-and-list-objects)).
+
+All `options` are passed directly to the internal [HTTParty](https://rubygems.org/gems/httparty) client.
 
 ### Getting large objects
 The `get_object` method with out a block is suitable for small objects that easily fit in memory. For larger objects, specify a block to process chunked data as it comes in.

--- a/lib/swift_client.rb
+++ b/lib/swift_client.rb
@@ -195,7 +195,7 @@ class SwiftClient
   def request(method, path, opts = {}, &block)
     headers = (opts[:headers] || {}).dup
     headers["X-Auth-Token"] = auth_token
-    headers["Accept"] ||= "application/json" unless opts.delete(:json) == false
+    headers["Accept"] ||= "application/json" unless opts[:query] && opts[:query][:format]
 
     stream_pos = opts[:body_stream].pos if opts[:body_stream]
 

--- a/test/swift_client_test.rb
+++ b/test/swift_client_test.rb
@@ -341,12 +341,12 @@ class SwiftClientTest < MiniTest::Test
     assert_equal objects, @swift_client.get_objects("container-1", :limit => 2, :marker => "object-2").parsed_response
   end
 
-  def test_get_objects_no_json
+  def test_get_objects_format_plain
     response = "object-2\nobject-3\n"
 
-    stub_request(:get, "https://example.com/v1/AUTH_account/container-1?limit=2&marker=object-2").with(:headers => { "X-Auth-Token" => "Token" }).to_return(:status => 200, :body => response, :headers => { "Content-Type" => "text/html" })
+    stub_request(:get, "https://example.com/v1/AUTH_account/container-1?format=plain&limit=2&marker=object-2").with(:headers => { "X-Auth-Token" => "Token" }).to_return(:status => 200, :body => response, :headers => { "Content-Type" => "text/plain" })
 
-    assert_equal response, @swift_client.get_objects("container-1", { :limit => 2, :marker => "object-2" }, :json => false).body
+    assert_equal response, @swift_client.get_objects("container-1", :format => "plain", :limit => 2, :marker => "object-2").body
   end
 
   def test_paginate_objects


### PR DESCRIPTION
The OpenStack Object Storage API allows the response body format to be given via an Accept header or`format` parameter. So if the latter is given then don't set the Accept header. This replaces the `json: false` option.

(Didn't realize this possibility in a previous PR!)